### PR TITLE
release/0.5.1 Add ami input to provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     iterative = {
       source = "iterative/iterative"
-      version = "0.5.0"
+      version = "0.5.1"
     }
   }
 }
@@ -32,6 +32,7 @@ resource "iterative_machine" "machine" {
 | Variable | Values | Default | |
 | ------- | ------ | -------- | ------------- |
 | ```region``` | ```us-west``` ```us-east``` ```eu-west``` ```eu-north``` | ```us-west``` | Sets the collocation region |
+| ```ami``` | | ```iterative-cml``` | Sets the ami to be used. For that the provider does a search in the cloud provider by image name not by id, taking the lastest version in case there are many with the same name. Defaults to [iterative-cml image](#iterative-cml-image) |
 | ```instance_name``` |  | cml_{UID} | Sets the instance name and related resources like AWS key pair. |
 | ```instance_hdd_size``` | | 10 | Sets the instance hard disk size in gb |
 | ```instance_type``` | ```m```, ```l```, ```xl``` | ```m``` | Sets thee instance computing size. You can also specify vendor specific machines in AWS i.e. ```t2.micro``` |
@@ -65,3 +66,11 @@ The instance type in AWS is calculated joining the ```instance_type``` and ```in
 | us-east | us-east-1 |
 | eu-north | us-north-1 |
 | eu-west | us-west-1 |
+
+# Iterative CML image
+
+It's a GPU ready image based on Ubuntu 18.04. It has the following stack already installed:
+
+ - nvidia drivers
+ - docker
+ - nvidia-docker

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 # Terraform Provider Iterative
 
-The Terraform Iterative provider is a plugin for Terraform that allows for the full lifecycle management of GPU or non GPU cloud resources with your favourite [vendor](#supported-vendors). The provider offers a simple and homogeneous way to deploy a GPU or a cluster of them reducing the complexity.
+The Terraform Iterative provider is a plugin for Terraform that allows for the
+full lifecycle management of GPU or non GPU cloud resources with your favourite
+[vendor](#supported-vendors). The provider offers a simple and homogeneous way
+to deploy a GPU or a cluster of them reducing the complexity.
 
 # Usage
 
@@ -29,48 +32,50 @@ resource "iterative_machine" "machine" {
 
 ## Argument reference
 
-| Variable | Values | Default | |
-| ------- | ------ | -------- | ------------- |
-| ```region``` | ```us-west``` ```us-east``` ```eu-west``` ```eu-north``` | ```us-west``` | Sets the collocation region |
-| ```ami``` | | ```iterative-cml``` | Sets the ami to be used. For that the provider does a search in the cloud provider by image name not by id, taking the lastest version in case there are many with the same name. Defaults to [iterative-cml image](#iterative-cml-image) |
-| ```instance_name``` |  | cml_{UID} | Sets the instance name and related resources like AWS key pair. |
-| ```instance_hdd_size``` | | 10 | Sets the instance hard disk size in gb |
-| ```instance_type``` | ```m```, ```l```, ```xl``` | ```m``` | Sets thee instance computing size. You can also specify vendor specific machines in AWS i.e. ```t2.micro``` |
-| ```instance_gpu``` | ``` ```, ```testla```, ```k80``` | ``` ``` | Sets the desired GPU  if the ```instance_type``` is one of our types. |
-| ```key_public``` | | | Set up ssh access with your OpenSSH public key. If not provided one be automatically generated and returned in terraform.tfstate  |
-| aws_security_group | | ```cml``` | AWS specific variable to setup an specific security group. If specified the instance will be launched in with that sg within the vpc managed by the specified sg. If not a new sg called ```cml``` will be created under the default vpc |
- 
+| Variable            | Values                                   | Default         |                                                                                                                                                                                                                                           |
+| ------------------- | ---------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `region`            | `us-west` `us-east` `eu-west` `eu-north` | `us-west`       | Sets the collocation region                                                                                                                                                                                                               |
+| `ami`               |                                          | `iterative-cml` | Sets the ami to be used. For that the provider does a search in the cloud provider by image name not by id, taking the lastest version in case there are many with the same name. Defaults to [iterative-cml image](#iterative-cml-image) |
+| `instance_name`     |                                          | cml\_{UID}      | Sets the instance name and related resources like AWS key pair.                                                                                                                                                                           |
+| `instance_hdd_size` |                                          | 10              | Sets the instance hard disk size in gb                                                                                                                                                                                                    |
+| `instance_type`     | `m`, `l`, `xl`                           | `m`             | Sets thee instance computing size. You can also specify vendor specific machines in AWS i.e. `t2.micro`                                                                                                                                   |
+| `instance_gpu`      | ``, `testla`, `k80`                      | ``              | Sets the desired GPU if the `instance_type` is one of our types.                                                                                                                                                                          |
+| `key_public`        |                                          |                 | Set up ssh access with your OpenSSH public key. If not provided one be automatically generated and returned in terraform.tfstate                                                                                                          |
+| aws_security_group  |                                          | `cml`           | AWS specific variable to setup an specific security group. If specified the instance will be launched in with that sg within the vpc managed by the specified sg. If not a new sg called `cml` will be created under the default vpc      |
 
 # Supported vendors
 
- - AWS
- 
+- AWS
+
 ### AWS instance equivalences.
-The instance type in AWS is calculated joining the ```instance_type``` and ```instance_gpu```
 
-| type | gpu | aws |
-| ------- | ------ | -------- |
-| m |  | m5.2xlarge |
-| l |  | m5.8xlarge |
-| xl |  | m5.16xlarge |
-| m | k80 | p2.xlarge |
-| l | k80 | p2.8xlarge |
-| xl | k80 | p2.16xlarge |
-| m | tesla | p3.xlarge |
-| l | tesla | p3.8xlarge |
-| xl | tesla | p3.16xlarge |
+The instance type in AWS is calculated joining the `instance_type` and
+`instance_gpu`
 
-| region | aws |
-| ------- | ------ |
-| us-west | us-west-1 |
-| us-east | us-east-1 |
+| type | gpu   | aws         |
+| ---- | ----- | ----------- |
+| m    |       | m5.2xlarge  |
+| l    |       | m5.8xlarge  |
+| xl   |       | m5.16xlarge |
+| m    | k80   | p2.xlarge   |
+| l    | k80   | p2.8xlarge  |
+| xl   | k80   | p2.16xlarge |
+| m    | tesla | p3.xlarge   |
+| l    | tesla | p3.8xlarge  |
+| xl   | tesla | p3.16xlarge |
+
+| region   | aws        |
+| -------- | ---------- |
+| us-west  | us-west-1  |
+| us-east  | us-east-1  |
 | eu-north | us-north-1 |
-| eu-west | us-west-1 |
+| eu-west  | us-west-1  |
 
 # Iterative CML image
 
-It's a GPU ready image based on Ubuntu 18.04. It has the following stack already installed:
+It's a GPU ready image based on Ubuntu 18.04. It has the following stack already
+installed:
 
- - nvidia drivers
- - docker
- - nvidia-docker
+- nvidia drivers
+- docker
+- nvidia-docker

--- a/iterative/resource_machine.go
+++ b/iterative/resource_machine.go
@@ -27,6 +27,12 @@ func resourceMachine() *schema.Resource {
 				ForceNew: true,
 				Default:  "us-west",
 			},
+			"ami": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "iterative-cml",
+			},
 			"instance_name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -112,11 +118,13 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(errClient)
 	}
 
+	ami := d.Get("ami").(string)
+
 	imagesRes, imagesErr := svc.DescribeImages(&ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("name"),
-				Values: []*string{aws.String("iterative-cml")},
+				Values: []*string{aws.String(ami)},
 			},
 			{
 				Name:   aws.String("architecture"),
@@ -130,7 +138,7 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 	if len(imagesRes.Images) == 0 {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "iterative-cml ami not found in region",
+			Summary:  ami + " ami not found in region",
 		})
 
 		return diags


### PR DESCRIPTION
Add ami input. It might be needed by the end user. We will need to add a provisioner function also in order to install custom packages.
