### PR TITLE
Fix dpkg frontend lock

### DIFF
--- a/cml/setup.sh
+++ b/cml/setup.sh
@@ -3,6 +3,9 @@
 DEBIAN_FRONTEND=noninteractive
 echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assumeyes
 
+sudo apt remove unattended-upgrades
+systemctl disable apt-daily-upgrade.service 
+
 sudo apt update
 sudo curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && \
 sudo usermod -aG docker ubuntu

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -228,6 +228,10 @@ export DEBIAN_FRONTEND=noninteractive
 
 {{if eq .cloud "azure"}}
 echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assumeyes
+
+sudo apt remove unattended-upgrades
+systemctl disable apt-daily-upgrade.service 
+
 sudo apt update
 sudo curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh
 sudo usermod -aG docker ubuntu


### PR DESCRIPTION
Ubuntu loves to upgrade itself. Those unattended upgrades have to be disabled to not conflict with current installs in workflows. 
closes #20 