### PR TITLE
Delete error and other non existing resources check

### DIFF
--- a/iterative/azure/provider.go
+++ b/iterative/azure/provider.go
@@ -265,12 +265,7 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	if err != nil {
 		return err
 	}
-	/*
-		err = future.WaitForCompletionRef(ctx, groupsClient.Client)
-		if err != nil {
-			return err
-		}
-	*/
+
 	return err
 }
 


### PR DESCRIPTION
This PRs fixes the several crashes that can occur due to AWS non present resources.
 - Only try to delete if the resource exists. closes #19 
 - Warns that VPC and/or subnet is not present
 - MInor code cleanup