### PR TITLE
GPU support without restart

### DIFF
--- a/cml/ami.json
+++ b/cml/ami.json
@@ -33,12 +33,6 @@
       "type": "shell",
       "environment_vars": ["DEBIAN_FRONTEND=noninteractive"],
       "script": "./setup.sh"
-    },
-    {
-      "type": "shell",
-      "inline": ["sudo shutdown -r now", "sleep 60"],
-      "start_retry_timeout": "10m",
-      "expect_disconnect": true
     }
   ]
 }

--- a/cml/setup.sh
+++ b/cml/setup.sh
@@ -6,6 +6,7 @@ echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assume
 sudo apt remove unattended-upgrades
 systemctl disable apt-daily-upgrade.service 
 
+sudo add-apt-repository universe -y
 sudo add-apt-repository ppa:git-core/ppa -y
 sudo apt update && sudo apt-get install -y git
 sudo curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && \
@@ -21,6 +22,12 @@ sudo apt update && sudo apt-get install -y nodejs
 
 sudo apt install -y ubuntu-drivers-common git
 sudo ubuntu-drivers autoinstall 
-curl -s -L https://nvidia.GitHub.io/nvidia-docker/gpgkey | sudo apt-key add - && \
-curl -s -L https://nvidia.GitHub.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-sudo apt update && sudo apt install -y nvidia-container-toolkit
+
+curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - 
+curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+sudo apt update && sudo apt install -y nvidia-docker2
+
+sudo systemctl restart docker
+
+sudo nvidia-smi
+sudo docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi


### PR DESCRIPTION
docker-nvidia needs to install nvidia-docker2 opposed to toolkit. Additionally the machine preparation has been set to not need restart