### PR TITLE
CML points to master

### DIFF
--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -273,7 +273,7 @@ sudo nvidia-smi
 sudo docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
 {{end}}
 
-sudo npm install -g git+https://github.com/iterative/cml.git#cml-runner
+sudo npm install -g git+https://github.com/iterative/cml.git
 
 sudo bash -c 'cat << EOF > /usr/bin/cml.sh
 #!/bin/sh


### PR DESCRIPTION
Changes the cml repo from cml-runner branch to master.
Probably makes sense to do npm package instead.

closes #46 