### PR TITLE
Rename AWS security group from cml to iterative

### DIFF
--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -76,7 +76,7 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 	// securityGroup
 	var vpcID, sgID string
 	if len(securityGroup) == 0 {
-		securityGroup = "cml"
+		securityGroup = "iterative"
 
 		vpcsDesc, _ := svc.DescribeVpcs(&ec2.DescribeVpcsInput{})
 		if len(vpcsDesc.Vpcs) == 0 {


### PR DESCRIPTION
Fixes #77, should not require any other change. 