### PR TITLE
Restrict inbound access to SSH

### DIFF
--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -91,7 +91,17 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 		})
 
 		if err == nil {
-			ipPermissions := []*ec2.IpPermission{
+			ipIngressPermissions := []*ec2.IpPermission{
+				(&ec2.IpPermission{}).
+					SetIpProtocol("tcp").
+					SetFromPort(22).
+					SetToPort(22).
+					SetIpRanges([]*ec2.IpRange{
+						{CidrIp: aws.String("0.0.0.0/0")},
+					}),
+			}
+
+			ipEgressPermissions := []*ec2.IpPermission{
 				(&ec2.IpPermission{}).
 					SetIpProtocol("-1").
 					SetFromPort(-1).
@@ -103,12 +113,12 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 			svc.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 				GroupId:       aws.String(*gpResult.GroupId),
-				IpPermissions: ipPermissions,
+				IpPermissions: ipIngressPermissions,
 			})
 
 			svc.AuthorizeSecurityGroupEgress(&ec2.AuthorizeSecurityGroupEgressInput{
 				GroupId:       aws.String(*gpResult.GroupId),
-				IpPermissions: ipPermissions,
+				IpPermissions: ipEgressPermissions,
 			})
 		}
 	}

--- a/iterative/azure/provider.go
+++ b/iterative/azure/provider.go
@@ -81,9 +81,9 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 							Protocol:                 network.SecurityRuleProtocolTCP,
 							SourceAddressPrefix:      to.StringPtr("0.0.0.0/0"),
-							SourcePortRange:          to.StringPtr("1-65535"),
+							SourcePortRange:          to.StringPtr("22"),
 							DestinationAddressPrefix: to.StringPtr("0.0.0.0/0"),
-							DestinationPortRange:     to.StringPtr("1-65535"),
+							DestinationPortRange:     to.StringPtr("22"),
 							Access:                   network.SecurityRuleAccessAllow,
 							Direction:                network.SecurityRuleDirectionInbound,
 							Priority:                 to.Int32Ptr(100),


### PR DESCRIPTION
> [_Another query, does the security group have to be fully open to inbound traffic or can I close it down without adverse effects?_](https://discord.com/channels/485586884165107732/728693131557732403/818836901842255964) **(From Discord)**

As this user suggested, we might want to thighten a bit the ingress permissions to avoid exposing ports other than SSH (TCP 22) in order to keep the instances as safe as possible.
