### PR TITLE
No SG found due to casing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ terraform
 
 # Ignore the Go vendor directory, superseded by proxy.golang.org and go.{mod,sum}
 vendor
+
+./terraform-provider-iterative

--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -142,8 +142,11 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 	sgDesc, err := svc.DescribeSecurityGroupsWithContext(ctx, &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("group-name"),
-				Values: []*string{aws.String(securityGroup), aws.String(strings.Title(securityGroup))},
+				Name: aws.String("group-name"),
+				Values: []*string{
+					aws.String(securityGroup),
+					aws.String(strings.Title(securityGroup)),
+					aws.String(strings.ToUpper(securityGroup))},
 			},
 		},
 	})

--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -129,13 +130,20 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 				IpPermissions: ipPermissions,
 			})
 		}
+
+		if err != nil {
+			decodedError := decodeAWSError(region, err)
+			if !strings.Contains(decodedError.Error(), "already exists for VPC") {
+				return decodedError
+			}
+		}
 	}
 
 	sgDesc, err := svc.DescribeSecurityGroupsWithContext(ctx, &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("group-name"),
-				Values: []*string{aws.String(securityGroup)},
+				Values: []*string{aws.String(securityGroup), aws.String(strings.Title(securityGroup))},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes the issue that AWS seems to be creating with uppercase and lowecase when creating and searching security groups.
Additionally warns in case the user has no permissions to create new SG.

Removes ./terraform-provider-iterative

closes https://github.com/iterative/cml/issues/447