### PR TITLE
Remove executable bit from the systemd service file

### DIFF
--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -319,7 +319,6 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
 [Install]
   WantedBy=multi-user.target
 EOF'
-sudo chmod +x /etc/systemd/system/cml.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable cml.service --now

--- a/iterative/testdata/script_template_cloud_aws.golden
+++ b/iterative/testdata/script_template_cloud_aws.golden
@@ -74,7 +74,6 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
 [Install]
   WantedBy=multi-user.target
 EOF'
-sudo chmod +x /etc/systemd/system/cml.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable cml.service --now

--- a/iterative/testdata/script_template_cloud_azure.golden
+++ b/iterative/testdata/script_template_cloud_azure.golden
@@ -75,7 +75,6 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
 [Install]
   WantedBy=multi-user.target
 EOF'
-sudo chmod +x /etc/systemd/system/cml.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable cml.service --now

--- a/iterative/testdata/script_template_cloud_invalid.golden
+++ b/iterative/testdata/script_template_cloud_invalid.golden
@@ -70,7 +70,6 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
 [Install]
   WantedBy=multi-user.target
 EOF'
-sudo chmod +x /etc/systemd/system/cml.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable cml.service --now


### PR DESCRIPTION
Not required, as per the `systemd` log messages:

> _Configuration file `/etc/systemd/system/cml.service` is marked executable. Please remove executable permission bits._

Closes #98 