### PR TITLE
Debug the instance IP prior to awaiting the runner

### DIFF
--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -190,7 +190,8 @@ func resourceRunnerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	if diags.HasError() {
 		return diags
 	}
-
+	log.Printf("[DEBUG] Instance address: %#v", d.Get("instance_ip"))
+	
 	var logError error
 	var logEvents string
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -191,7 +191,7 @@ func resourceRunnerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		return diags
 	}
 	log.Printf("[DEBUG] Instance address: %#v", d.Get("instance_ip"))
-	
+
 	var logError error
 	var logEvents string
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {


### PR DESCRIPTION
This would be extremely useful for debugging some connection issues.