### PR TITLE
Use CombinedOutput for capturing SSH output

### DIFF
--- a/iterative/utils/ssh.go
+++ b/iterative/utils/ssh.go
@@ -75,6 +75,6 @@ func RunCommand(command string, timeout time.Duration, hostAddress string, userN
 	if err != nil {
 		return "", err
 	}
-	
+
 	return string(output), nil
 }

--- a/iterative/utils/ssh.go
+++ b/iterative/utils/ssh.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -72,10 +71,10 @@ func RunCommand(command string, timeout time.Duration, hostAddress string, userN
 	}
 	defer session.Close()
 
-	var buffer bytes.Buffer
-	session.Stdout = &buffer
-	session.Stderr = &buffer
-
-	err = session.Run(command)
-	return buffer.String(), err
+	output, err := session.CombinedOutput(command)
+	if err != nil {
+		return "", err
+	}
+	
+	return string(output), nil
 }


### PR DESCRIPTION
Fixes a buffer writing bug where the function would return an empty string after a succesful read