### PR TITLE
Reboot to enable nvidia

### DIFF
--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -270,7 +270,8 @@ sudo apt update && sudo apt-get install -y terraform
 curl -sL https://deb.nodesource.com/setup_12.x | sudo bash
 sudo apt update && sudo apt-get install -y nodejs
 
-sudo apt install ubuntu-drivers-common
+sudo add-apt-repository ppa:graphics-drivers/ppa -y
+sudo apt update && sudo apt install ubuntu-drivers-common
 sudo ubuntu-drivers autoinstall
 curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
@@ -337,8 +338,8 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
   WantedBy=multi-user.target
 EOF'
 
-sudo systemctl daemon-reload
-sudo systemctl enable cml.service --now
+sudo systemctl enable cml.service
+sudo reboot
 {{- end}}
 `)
 	var customDataBuffer bytes.Buffer

--- a/iterative/testdata/script_template_cloud_aws.golden
+++ b/iterative/testdata/script_template_cloud_aws.golden
@@ -21,7 +21,8 @@ sudo apt update && sudo apt-get install -y terraform
 curl -sL https://deb.nodesource.com/setup_12.x | sudo bash
 sudo apt update && sudo apt-get install -y nodejs
 
-sudo apt install ubuntu-drivers-common
+sudo add-apt-repository ppa:graphics-drivers/ppa -y
+sudo apt update && sudo apt install ubuntu-drivers-common
 sudo ubuntu-drivers autoinstall
 curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
@@ -77,5 +78,5 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
   WantedBy=multi-user.target
 EOF'
 
-sudo systemctl daemon-reload
-sudo systemctl enable cml.service --now
+sudo systemctl enable cml.service
+sudo reboot

--- a/iterative/testdata/script_template_cloud_azure.golden
+++ b/iterative/testdata/script_template_cloud_azure.golden
@@ -21,7 +21,8 @@ sudo apt update && sudo apt-get install -y terraform
 curl -sL https://deb.nodesource.com/setup_12.x | sudo bash
 sudo apt update && sudo apt-get install -y nodejs
 
-sudo apt install ubuntu-drivers-common
+sudo add-apt-repository ppa:graphics-drivers/ppa -y
+sudo apt update && sudo apt install ubuntu-drivers-common
 sudo ubuntu-drivers autoinstall
 curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
@@ -78,5 +79,5 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
   WantedBy=multi-user.target
 EOF'
 
-sudo systemctl daemon-reload
-sudo systemctl enable cml.service --now
+sudo systemctl enable cml.service
+sudo reboot

--- a/iterative/testdata/script_template_cloud_invalid.golden
+++ b/iterative/testdata/script_template_cloud_invalid.golden
@@ -21,7 +21,8 @@ sudo apt update && sudo apt-get install -y terraform
 curl -sL https://deb.nodesource.com/setup_12.x | sudo bash
 sudo apt update && sudo apt-get install -y nodejs
 
-sudo apt install ubuntu-drivers-common
+sudo add-apt-repository ppa:graphics-drivers/ppa -y
+sudo apt update && sudo apt install ubuntu-drivers-common
 sudo ubuntu-drivers autoinstall
 curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
@@ -73,5 +74,5 @@ sudo bash -c 'cat << EOF > /etc/systemd/system/cml.service
   WantedBy=multi-user.target
 EOF'
 
-sudo systemctl daemon-reload
-sudo systemctl enable cml.service --now
+sudo systemctl enable cml.service
+sudo reboot


### PR DESCRIPTION
Seems that nvidia needs to be rebooted now. So we are rebooting and enabling cml after reboot, additionally we are adding the latest nvidia ppa. 
