### PR TITLE
Fix nil pointer dereference on SSH key parser

### DIFF
--- a/iterative/utils/ssh.go
+++ b/iterative/utils/ssh.go
@@ -5,10 +5,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"strings"
 	"time"
-	"fmt"
-	
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -32,7 +32,7 @@ func PublicFromPrivatePEM(privateKey string) (string, error) {
 	if block == nil {
 		return "", fmt.Errorf("Invalid PEM on the SSH private key: %#v", rest)
 	}
-	
+
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return "", err

--- a/iterative/utils/ssh.go
+++ b/iterative/utils/ssh.go
@@ -7,7 +7,8 @@ import (
 	"encoding/pem"
 	"strings"
 	"time"
-
+	"fmt"
+	
 	"golang.org/x/crypto/ssh"
 )
 
@@ -27,7 +28,11 @@ func PrivatePEM() (string, error) {
 }
 
 func PublicFromPrivatePEM(privateKey string) (string, error) {
-	block, _ := pem.Decode([]byte(privateKey))
+	block, rest := pem.Decode([]byte(privateKey))
+	if block == nil {
+		return "", fmt.Errorf("Invalid PEM on the SSH private key: %#v", rest)
+	}
+	
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Triggered when feeding with an invalid key

> ```go
> func Decode(data []byte) (p *Block, rest []byte)
> ```
> [_If no PEM data is found, `p` is `nil` and the whole of the input is returned in rest._](https://golang.org/pkg/encoding/pem/#Decode )