### PR TITLE
Mark startup script as sensitive

### DIFF
--- a/iterative/resource_machine.go
+++ b/iterative/resource_machine.go
@@ -108,10 +108,10 @@ func machineSchema() *map[string]*schema.Schema {
 			Computed: true,
 		},
 		"startup_script": &schema.Schema{
-			Type:     schema.TypeString,
-			ForceNew: true,
-			Optional: true,
-			Default:  "#!/bin/bash",
+			Type:      schema.TypeString,
+			ForceNew:  true,
+			Optional:  true,
+			Default:   "#!/bin/bash",
 			Sensitive: true,
 		},
 		"aws_security_group": &schema.Schema{

--- a/iterative/resource_machine.go
+++ b/iterative/resource_machine.go
@@ -112,6 +112,7 @@ func machineSchema() *map[string]*schema.Schema {
 			ForceNew: true,
 			Optional: true,
 			Default:  "#!/bin/bash",
+			Sensitive: true,
 		},
 		"aws_security_group": &schema.Schema{
 			Type:     schema.TypeString,

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -141,10 +141,10 @@ func resourceRunner() *schema.Resource {
 				Sensitive: true,
 			},
 			"startup_script": &schema.Schema{
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-				Default:  "",
+				Type:      schema.TypeString,
+				ForceNew:  true,
+				Optional:  true,
+				Default:   "",
 				Sensitive: true,
 			},
 			"aws_security_group": &schema.Schema{

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -145,6 +145,7 @@ func resourceRunner() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 				Default:  "",
+				Sensitive: true,
 			},
 			"aws_security_group": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
Far from being an ideal solution, it will mitigate some plaintext secret leak issues on errored runs.