### PR TITLE
Fix nil dereferencing on template errors

### DIFF
--- a/iterative/resource_runner_test.go
+++ b/iterative/resource_runner_test.go
@@ -15,7 +15,8 @@ func TestScript(t *testing.T) {
 		data := make(map[string]interface{})
 		data["ami"] = isAMIAvailable("aws", "us-east-1")
 
-		script, _ := renderScript(data)
+		script, err := renderScript(data)
+		assert.Nil(t, err)
 		assert.NotContains(t, script, "sudo ubuntu-drivers autoinstall")
 	})
 
@@ -23,7 +24,8 @@ func TestScript(t *testing.T) {
 		data := make(map[string]interface{})
 		data["ami"] = isAMIAvailable("aws", "us-east-99")
 
-		script, _ := renderScript(data)
+		script, err := renderScript(data)
+		assert.Nil(t, err)
 		assert.Contains(t, script, "sudo ubuntu-drivers autoinstall")
 	})
 
@@ -31,7 +33,8 @@ func TestScript(t *testing.T) {
 		data := make(map[string]interface{})
 		data["ami"] = isAMIAvailable("azure", "westus")
 
-		script, _ := renderScript(data)
+		script, err := renderScript(data)
+		assert.Nil(t, err)
 		assert.Contains(t, script, "sudo ubuntu-drivers autoinstall")
 	})
 
@@ -39,7 +42,8 @@ func TestScript(t *testing.T) {
 		data := make(map[string]interface{})
 		data["ami"] = isAMIAvailable("azure", "us-east-99")
 
-		script, _ := renderScript(data)
+		script, err := renderScript(data)
+		assert.Nil(t, err)
 		assert.Contains(t, script, "sudo ubuntu-drivers autoinstall")
 	})
 
@@ -48,7 +52,8 @@ func TestScript(t *testing.T) {
 		startupScript, _ := base64.StdEncoding.DecodeString("ZWNobyAiaGVsbG8gd29ybGQiCmVjaG8gImJ5ZSB3b3JsZCI=")
 		data["runner_startup_script"] = string(startupScript)
 
-		script, _ := renderScript(data)
+		script, err := renderScript(data)
+		assert.Nil(t, err)
 		assert.Contains(t, script, "echo \"hello world\"\necho \"bye world\"")
 	})
 }


### PR DESCRIPTION
```
--- FAIL: TestScript/AWS_known_region_should_not_add_the_NVIDA_drivers (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1c2e460]
```