### PR TITLE
AWS better check and election

### DIFF
--- a/iterative/azure/provider.go
+++ b/iterative/azure/provider.go
@@ -30,7 +30,7 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	username := "ubuntu"
 	customData := d.Get("startup_script").(string)
-	region := getRegion(d.Get("region").(string))
+	region := GetRegion(d.Get("region").(string))
 	instanceType := getInstanceType(d.Get("instance_type").(string), d.Get("instance_gpu").(string))
 	keyPublic := d.Get("ssh_public").(string)
 	hddSize := int32(d.Get("instance_hdd_size").(int))
@@ -354,7 +354,8 @@ func getVMClient(subscriptionID string) (compute.VirtualMachinesClient, error) {
 //ImageRegions provider available image regions
 var ImageRegions = []string{}
 
-func getRegion(region string) string {
+//GetRegion maps region to real cloud regions
+func GetRegion(region string) string {
 	instanceRegions := make(map[string]string)
 	instanceRegions["us-east"] = "eastus"
 	instanceRegions["us-west"] = "westus2"

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -437,8 +437,16 @@ func isAMIAvailable(cloud string, region string) bool {
 		regions = azure.ImageRegions
 	}
 
+	var cloudRegion string
+	switch cloud {
+	case "aws":
+		cloudRegion = aws.GetRegion(region)
+	case "azure":
+		cloudRegion = azure.GetRegion(region)
+	}
+
 	for _, item := range regions {
-		if item == region {
+		if item == cloudRegion {
 			return true
 		}
 	}

--- a/iterative/resource_runner_test.go
+++ b/iterative/resource_runner_test.go
@@ -21,6 +21,15 @@ func TestScript(t *testing.T) {
 		assert.NotContains(t, script, "sudo ubuntu-drivers autoinstall")
 	})
 
+	t.Run("AWS known generic region should not add the NVIDA drivers", func(t *testing.T) {
+		data := make(map[string]interface{})
+		data["ami"] = isAMIAvailable("aws", "us-west")
+
+		script, err := renderScript(data)
+		assert.Nil(t, err)
+		assert.NotContains(t, script, "sudo ubuntu-drivers autoinstall")
+	})
+
 	t.Run("AWS unknown region should add the NVIDA drivers", func(t *testing.T) {
 		data := make(map[string]interface{})
 		data["ami"] = isAMIAvailable("aws", "us-east-99")
@@ -33,6 +42,15 @@ func TestScript(t *testing.T) {
 	t.Run("Azure known region should add the NVIDA drivers", func(t *testing.T) {
 		data := make(map[string]interface{})
 		data["ami"] = isAMIAvailable("azure", "westus")
+
+		script, err := renderScript(data)
+		assert.Nil(t, err)
+		assert.Contains(t, script, "sudo ubuntu-drivers autoinstall")
+	})
+
+	t.Run("Azure known generic region should add the NVIDA drivers", func(t *testing.T) {
+		data := make(map[string]interface{})
+		data["ami"] = isAMIAvailable("azure", "us-west")
 
 		script, err := renderScript(data)
 		assert.Nil(t, err)


### PR DESCRIPTION
 - Ensures that the Ubuntu image is developed by Canonical
 - Chooses the default VPC and not the very first one
 - Ensures that the subnet can create public IPs and it has available IPs still
 - Checks the iterative mapped regions to determine if ami is available. closes #99 
 - Sets the used ami name in the tfstate