### PR TITLE
Fix nil pointer derreference on AWS resource destroy

### DIFF
--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -335,7 +335,7 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	if err != nil {
 		return err
 	}
-	
+
 	if len(descResult.Reservations) > 0 && len(descResult.Reservations[0].Instances) > 0 {
 		instanceID := *descResult.Reservations[0].Instances[0].InstanceId
 		_, err = svc.TerminateInstances(&ec2.TerminateInstancesInput{

--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -332,6 +332,10 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 			},
 		},
 	})
+	if err != nil {
+		return err
+	}
+	
 	if len(descResult.Reservations) > 0 && len(descResult.Reservations[0].Instances) > 0 {
 		instanceID := *descResult.Reservations[0].Instances[0].InstanceId
 		_, err = svc.TerminateInstances(&ec2.TerminateInstancesInput{


### PR DESCRIPTION
~Probably discovered by @DavidGOrtega on https://github.com/iterative/terraform-provider-iterative/pull/187#issuecomment-916046982.~ Unrelated: serendipity discovery by @0x2b3bfa0 