### PR TITLE
Fix ineffective sudo usage in setup.sh

### DIFF
--- a/cml/setup.sh
+++ b/cml/setup.sh
@@ -30,5 +30,5 @@ if [ ! -f "$FILE" ]; then
   sudo apt update && sudo apt install -y nvidia-docker2
   sudo systemctl restart docker
 
-  sudo echo 'OK' >"$FILE"
+  echo OK | sudo tee "$FILE"
 fi


### PR DESCRIPTION
Overlooked when reviewing #170, `sudo` is being applied to `echo` but the redirection operator still has the permissions of the main process.