### PR TITLE
Use system date in seconds for development version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HOSTNAME=github.com
 NAMESPACE=iterative
 NAME=iterative
-VERSION=0.0.0+development
+VERSION=0.0.${shell date +%s}+development
 OS_ARCH=${shell go env GOOS}_${shell go env GOARCH}
 BINARY=terraform-provider-${NAME}
 INSTALL_PATH=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}


### PR DESCRIPTION
This will eliminate the pain of removing `.terraform.lock.hcl` between `make install` and `terraform init`