### PR TITLE
Document environment variable globbing

### DIFF
--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -40,7 +40,7 @@ resource "iterative_task" "task" {
 - `image` - (Optional) [Machine image](#machine-images) to run the task with.
 - `parallelism` - (Optional) Number of machines to be launched in parallel.
 - `directory` - (Optional) Local directory to synchronize.
-- `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. When using empty string values and a [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) name, all the matching variables will be imported.
+- `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. Empty values may also be combined with a [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) name to import all matching variables.
 - `timeout` - (Optional) Maximum number of seconds to run before termination.
 
 ## Attribute Reference

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -40,7 +40,7 @@ resource "iterative_task" "task" {
 - `image` - (Optional) [Machine image](#machine-images) to run the task with.
 - `parallelism` - (Optional) Number of machines to be launched in parallel.
 - `directory` - (Optional) Local directory to synchronize.
-- `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values.
+- `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. When using empty string values and a [glob](https://en.wikipedia.org/wiki/Glob_(programming)) name, all the matching variables will be imported.
 - `timeout` - (Optional) Maximum number of seconds to run before termination.
 
 ## Attribute Reference

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -40,7 +40,7 @@ resource "iterative_task" "task" {
 - `image` - (Optional) [Machine image](#machine-images) to run the task with.
 - `parallelism` - (Optional) Number of machines to be launched in parallel.
 - `directory` - (Optional) Local directory to synchronize.
-- `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. When using empty string values and a [glob](https://en.wikipedia.org/wiki/Glob_(programming)) name, all the matching variables will be imported.
+- `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. When using empty string values and a [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) name, all the matching variables will be imported.
 - `timeout` - (Optional) Maximum number of seconds to run before termination.
 
 ## Attribute Reference


### PR DESCRIPTION
# From https://github.com/iterative/terraform-provider-iterative/pull/237#issuecomment-971075297

> 447a138 usage is as follows:
> 
> ```hcl
> resource "iterative_task" "example" {
>   ···
>   environment = {
>     VARIABLE = "value"
>     "GITHUB_*" = ""
>   }
>   ···
> }
> ```
> 
> If the variable value is an empty string (""), the variable name is going to be interpreted as a glob, including all the variables from the host environment.