### PR TITLE
Fix unsafe access to event time on Azure

### DIFF
--- a/task/az/resources/resource_virtual_machine_scale_set.go
+++ b/task/az/resources/resource_virtual_machine_scale_set.go
@@ -240,8 +240,12 @@ func (v *VirtualMachineScaleSet) Read(ctx context.Context) error {
 	}
 	if scaleSetView.Statuses != nil {
 		for _, status := range *scaleSetView.Statuses {
+			statusTime := time.Unix(0, 0)
+			if status.Time != nil {
+				statusTime = status.Time.Time
+			}
 			v.Attributes.Events = append(v.Attributes.Events, common.Event{
-				Time: status.Time.Time,
+				Time: statusTime,
 				Code: to.String(status.Code),
 				Description: []string{
 					string(status.Level),


### PR DESCRIPTION
The [`Time`](https://pkg.go.dev/github.com/Azure/go-autorest/autorest/date#Time) field of [`InstanceViewStatus`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute#InstanceViewStatus) is a pointer and may be `<nil>` in some edge cases.

Found when manually scaling out the Azure Scale Set while the provider was trying to scale it down. See https://github.com/iterative/terraform-provider-iterative/runs/4306049406?check_suite_focus=true#step:6:50 for the full logs.

```
--- FAIL: TestTask (0.98s)
    --- FAIL: TestTask/az (0.98s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2ceaea5]

goroutine 10 [running]:
testing.tRunner.func1.2(***0x42d4ba0, 0x67baae0***)
	/opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1212 +0x218
panic(***0x42d4ba0, 0x67baae0***)
	/opt/hostedtoolcache/go/1.17.3/x64/src/runtime/panic.go:1038 +0x215
terraform-provider-iterative/task/az/resources.(*VirtualMachineScaleSet).Read(0xc000246d80, ***0x4e79e90, 0xc000136008***)
	/home/runner/work/terraform-provider-iterative/terraform-provider-iterative/task/az/resources/resource_virtual_machine_scale_set.go:244 +0x8e5
terraform-provider-iterative/task/az.(*Task).Read(0xc000246c60, ***0x4e79e90, 0xc000136008***)
	/home/runner/work/terraform-provider-iterative/terraform-provider-iterative/task/az/task.go:175 +0x2d4
terraform-provider-iterative/task/az.(*Task).Delete(0xc000246c60, ***0x4e79e90, 0xc000136008***)
	/home/runner/work/terraform-provider-iterative/terraform-provider-iterative/task/az/task.go:187 +0x76
terraform-provider-iterative/task.TestTask.func1(0xc0004ed860)
	/home/runner/work/terraform-provider-iterative/terraform-provider-iterative/task/task_test.go:102 +0x4b1
testing.tRunner(0xc0004ed860, 0xc00031eee0)
	/opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1306 +0x35a
FAIL	terraform-provider-iterative/task	1.022s
FAIL
```