### PR TITLE
Disable spot on tests

### DIFF
--- a/task/task_test.go
+++ b/task/task_test.go
@@ -90,7 +90,7 @@ func TestTask(t *testing.T) {
 					},
 					// Egress: everything open.
 				},
-				Spot:        common.SpotEnabled,
+				Spot:        common.SpotDisabled,
 				Parallelism: 1,
 			}
 


### PR DESCRIPTION
Infrastructure tests are flaky enough without using spot instances.