### PR TITLE
Revert "test(k8s): move test cluster to westus"

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -80,7 +80,7 @@ jobs:
           --name=GPUDedicatedVHDPreview
         az group create \
           --name="tpiSmokeTestCluster$GITHUB_RUN_ID" \
-          --location=westus
+          --location=eastus
         az aks create \
           --resource-group="tpiSmokeTestCluster$GITHUB_RUN_ID" \
           --name="tpiSmokeTestCluster$GITHUB_RUN_ID" \


### PR DESCRIPTION
Reverts iterative/terraform-provider-iterative#288

> _ERROR: (VMSizeNotSupported) Virtual Machine size: 'Standard_NC6' is not supported for subscription *** in location 'westus'. The available VM sizes are:_

> </blockquote><details><summary>...</summary>

 > * standard_a2
 > * standard_a2_v2
 > * standard_a2m_v2
 > * standard_a3
 > * standard_a4
 > * standard_a4_v2
 > * standard_a4m_v2
 > * standard_a5
 > * standard_a6
 > * standard_a7
 > * standard_a8_v2
 > * standard_a8m_v2
 > * standard_b12ms
 > * standard_b16ms
 > * standard_b20ms
 > * standard_b2ms
 > * standard_b2s
 > * standard_b4ms
 > * standard_b8ms
 > * standard_d11
 > * standard_d11_v2
 > * standard_d12
 > * standard_d12_v2
 > * standard_d13
 > * standard_d13_v2
 > * standard_d14
 > * standard_d14_v2
 > * standard_d15_v2
 > * standard_d16_v3
 > * standard_d16_v4
 > * standard_d16_v5
 > * standard_d16a_v4
 > * standard_d16as_v4
 > * standard_d16d_v4
 > * standard_d16d_v5
 > * standard_d16ds_v4
 > * standard_d16ds_v5
 > * standard_d16s_v3
 > * standard_d16s_v4
 > * standard_d16s_v5
 > * standard_d2
 > * standard_d2_v2
 > * standard_d2_v3
 > * standard_d2_v4
 > * standard_d2_v5
 > * standard_d2a_v4
 > * standard_d2as_v4
 > * standard_d2d_v4
 > * standard_d2d_v5
 > * standard_d2ds_v4
 > * standard_d2ds_v5
 > * standard_d2s_v3
 > * standard_d2s_v4
 > * standard_d2s_v5
 > * standard_d3
 > * standard_d32_v3
 > * standard_d32_v4
 > * standard_d32_v5
 > * standard_d32a_v4
 > * standard_d32as_v4
 > * standard_d32d_v4
 > * standard_d32d_v5
 > * standard_d32ds_v4
 > * standard_d32ds_v5
 > * standard_d32s_v3
 > * standard_d32s_v4
 > * standard_d32s_v5
 > * standard_d3_v2
 > * standard_d4
 > * standard_d48_v3
 > * standard_d48_v4
 > * standard_d48_v5
 > * standard_d48a_v4
 > * standard_d48as_v4
 > * standard_d48d_v4
 > * standard_d48d_v5
 > * standard_d48ds_v4
 > * standard_d48ds_v5
 > * standard_d48s_v3
 > * standard_d48s_v4
 > * standard_d48s_v5
 > * standard_d4_v2
 > * standard_d4_v3
 > * standard_d4_v4
 > * standard_d4_v5
 > * standard_d4a_v4
 > * standard_d4as_v4
 > * standard_d4d_v4
 > * standard_d4d_v5
 > * standard_d4ds_v4
 > * standard_d4ds_v5
 > * standard_d4s_v3
 > * standard_d4s_v4
 > * standard_d4s_v5
 > * standard_d5_v2
 > * standard_d64_v3
 > * standard_d64_v4
 > * standard_d64_v5
 > * standard_d64a_v4
 > * standard_d64as_v4
 > * standard_d64d_v4
 > * standard_d64d_v5
 > * standard_d64ds_v4
 > * standard_d64ds_v5
 > * standard_d64s_v3
 > * standard_d64s_v4
 > * standard_d64s_v5
 > * standard_d8_v3
 > * standard_d8_v4
 > * standard_d8_v5
 > * standard_d8a_v4
 > * standard_d8as_v4
 > * standard_d8d_v4
 > * standard_d8d_v5
 > * standard_d8ds_v4
 > * standard_d8ds_v5
 > * standard_d8s_v3
 > * standard_d8s_v4
 > * standard_d8s_v5
 > * standard_d96_v5
 > * standard_d96a_v4
 > * standard_d96as_v4
 > * standard_d96d_v5
 > * standard_d96ds_v5
 > * standard_d96s_v5
 > * standard_dc16ads_v5
 > * standard_dc16as_v5
 > * standard_dc2ads_v5
 > * standard_dc2as_v5
 > * standard_dc2s_v2
 > * standard_dc32ads_v5
 > * standard_dc32as_v5
 > * standard_dc48ads_v5
 > * standard_dc48as_v5
 > * standard_dc4ads_v5
 > * standard_dc4as_v5
 > * standard_dc4s_v2
 > * standard_dc64ads_v5
 > * standard_dc64as_v5
 > * standard_dc8_v2
 > * standard_dc8ads_v5
 > * standard_dc8as_v5
 > * standard_dc96ads_v5
 > * standard_dc96as_v5
 > * standard_ds11
 > * standard_ds11-1_v2
 > * standard_ds11_v2
 > * standard_ds12
 > * standard_ds12-1_v2
 > * standard_ds12-2_v2
 > * standard_ds12_v2
 > * standard_ds13
 > * standard_ds13-2_v2
 > * standard_ds13-4_v2
 > * standard_ds13_v2
 > * standard_ds14
 > * standard_ds14-4_v2
 > * standard_ds14-8_v2
 > * standard_ds14_v2
 > * standard_ds15_v2
 > * standard_ds2
 > * standard_ds2_v2
 > * standard_ds3
 > * standard_ds3_v2
 > * standard_ds4
 > * standard_ds4_v2
 > * standard_ds5_v2
 > * standard_e104i_v5
 > * standard_e104id_v5
 > * standard_e104ids_v5
 > * standard_e104is_v5
 > * standard_e16-4as_v4
 > * standard_e16-4ds_v4
 > * standard_e16-4ds_v5
 > * standard_e16-4s_v3
 > * standard_e16-4s_v4
 > * standard_e16-4s_v5
 > * standard_e16-8as_v4
 > * standard_e16-8ds_v4
 > * standard_e16-8ds_v5
 > * standard_e16-8s_v3
 > * standard_e16-8s_v4
 > * standard_e16-8s_v5
 > * standard_e16_v3
 > * standard_e16_v4
 > * standard_e16_v5
 > * standard_e16a_v4
 > * standard_e16as_v4
 > * standard_e16d_v4
 > * standard_e16d_v5
 > * standard_e16ds_v4
 > * standard_e16ds_v5
 > * standard_e16s_v3
 > * standard_e16s_v4
 > * standard_e16s_v5
 > * standard_e20_v3
 > * standard_e20_v4
 > * standard_e20_v5
 > * standard_e20a_v4
 > * standard_e20as_v4
 > * standard_e20d_v4
 > * standard_e20d_v5
 > * standard_e20ds_v4
 > * standard_e20ds_v5
 > * standard_e20s_v3
 > * standard_e20s_v4
 > * standard_e20s_v5
 > * standard_e2_v3
 > * standard_e2_v4
 > * standard_e2_v5
 > * standard_e2a_v4
 > * standard_e2as_v4
 > * standard_e2d_v4
 > * standard_e2d_v5
 > * standard_e2ds_v4
 > * standard_e2ds_v5
 > * standard_e2s_v3
 > * standard_e2s_v4
 > * standard_e2s_v5
 > * standard_e32-16as_v4
 > * standard_e32-16ds_v4
 > * standard_e32-16ds_v5
 > * standard_e32-16s_v3
 > * standard_e32-16s_v4
 > * standard_e32-16s_v5
 > * standard_e32-8as_v4
 > * standard_e32-8ds_v4
 > * standard_e32-8ds_v5
 > * standard_e32-8s_v3
 > * standard_e32-8s_v4
 > * standard_e32-8s_v5
 > * standard_e32_v3
 > * standard_e32_v4
 > * standard_e32_v5
 > * standard_e32a_v4
 > * standard_e32as_v4
 > * standard_e32d_v4
 > * standard_e32d_v5
 > * standard_e32ds_v4
 > * standard_e32ds_v5
 > * standard_e32s_v3
 > * standard_e32s_v4
 > * standard_e32s_v5
 > * standard_e4-2as_v4
 > * standard_e4-2ds_v4
 > * standard_e4-2ds_v5
 > * standard_e4-2s_v3
 > * standard_e4-2s_v4
 > * standard_e4-2s_v5
 > * standard_e48_v3
 > * standard_e48_v4
 > * standard_e48_v5
 > * standard_e48a_v4
 > * standard_e48as_v4
 > * standard_e48d_v4
 > * standard_e48d_v5
 > * standard_e48ds_v4
 > * standard_e48ds_v5
 > * standard_e48s_v3
 > * standard_e48s_v4
 > * standard_e48s_v5
 > * standard_e4_v3
 > * standard_e4_v4
 > * standard_e4_v5
 > * standard_e4a_v4
 > * standard_e4as_v4
 > * standard_e4d_v4
 > * standard_e4d_v5
 > * standard_e4ds_v4
 > * standard_e4ds_v5
 > * standard_e4s_v3
 > * standard_e4s_v4
 > * standard_e4s_v5
 > * standard_e64-16as_v4
 > * standard_e64-16ds_v4
 > * standard_e64-16ds_v5
 > * standard_e64-16s_v3
 > * standard_e64-16s_v4
 > * standard_e64-16s_v5
 > * standard_e64-32as_v4
 > * standard_e64-32ds_v4
 > * standard_e64-32ds_v5
 > * standard_e64-32s_v3
 > * standard_e64-32s_v4
 > * standard_e64-32s_v5
 > * standard_e64_v3
 > * standard_e64_v4
 > * standard_e64_v5
 > * standard_e64a_v4
 > * standard_e64as_v4
 > * standard_e64d_v4
 > * standard_e64d_v5
 > * standard_e64ds_v4
 > * standard_e64ds_v5
 > * standard_e64i_v3
 > * standard_e64is_v3
 > * standard_e64s_v3
 > * standard_e64s_v4
 > * standard_e64s_v5
 > * standard_e8-2as_v4
 > * standard_e8-2ds_v4
 > * standard_e8-2ds_v5
 > * standard_e8-2s_v3
 > * standard_e8-2s_v4
 > * standard_e8-2s_v5
 > * standard_e8-4as_v4
 > * standard_e8-4ds_v4
 > * standard_e8-4ds_v5
 > * standard_e8-4s_v3
 > * standard_e8-4s_v4
 > * standard_e8-4s_v5
 > * standard_e80ids_v4
 > * standard_e80is_v4
 > * standard_e8_v3
 > * standard_e8_v4
 > * standard_e8_v5
 > * standard_e8a_v4
 > * standard_e8as_v4
 > * standard_e8d_v4
 > * standard_e8d_v5
 > * standard_e8ds_v4
 > * standard_e8ds_v5
 > * standard_e8s_v3
 > * standard_e8s_v4
 > * standard_e8s_v5
 > * standard_e96-24as_v4
 > * standard_e96-24ds_v5
 > * standard_e96-24s_v5
 > * standard_e96-48as_v4
 > * standard_e96-48ds_v5
 > * standard_e96-48s_v5
 > * standard_e96_v5
 > * standard_e96a_v4
 > * standard_e96as_v4
 > * standard_e96d_v5
 > * standard_e96ds_v5
 > * standard_e96s_v5
 > * standard_ec16ads_v5
 > * standard_ec16as_v5
 > * standard_ec20ads_v5
 > * standard_ec20as_v5
 > * standard_ec2ads_v5
 > * standard_ec2as_v5
 > * standard_ec32ads_v5
 > * standard_ec32as_v5
 > * standard_ec48ads_v5
 > * standard_ec48as_v5
 > * standard_ec4ads_v5
 > * standard_ec4as_v5
 > * standard_ec64ads_v5
 > * standard_ec64as_v5
 > * standard_ec8ads_v5
 > * standard_ec8as_v5
 > * standard_ec96ads_v5
 > * standard_ec96as_v5
 > * standard_ec96iads_v5
 > * standard_ec96ias_v5
 > * standard_f16
 > * standard_f16s
 > * standard_f16s_v2
 > * standard_f2
 > * standard_f2s
 > * standard_f2s_v2
 > * standard_f32s_v2
 > * standard_f4
 > * standard_f48s_v2
 > * standard_f4s
 > * standard_f4s_v2
 > * standard_f64s_v2
 > * standard_f72s_v2
 > * standard_f8
 > * standard_f8s
 > * standard_f8s_v2
 > * standard_g1
 > * standard_g2
 > * standard_g3
 > * standard_g4
 > * standard_g5
 > * standard_gs1
 > * standard_gs2
 > * standard_gs3
 > * standard_gs4
 > * standard_gs4-4
 > * standard_gs4-8
 > * standard_gs5
 > * standard_gs5-16
 > * standard_gs5-8
 > * standard_h16
 > * standard_h16_promo
 > * standard_h16m
 > * standard_h16m_promo
 > * standard_h16mr
 > * standard_h16mr_promo
 > * standard_h16r
 > * standard_h16r_promo
 > * standard_h8
 > * standard_h8_promo
 > * standard_h8m
 > * standard_h8m_promo
 > * standard_l16s
 > * standard_l16s_v2
 > * standard_l32s
 > * standard_l32s_v2
 > * standard_l48s_v2
 > * standard_l4s
 > * standard_l64s_v2
 > * standard_l80s_v2
 > * standard_l8s
 > * standard_l8s_v2
 > * standard_m128
 > * standard_m128-32ms
 > * standard_m128-64ms
 > * standard_m128dms_v2
 > * standard_m128ds_v2
 > * standard_m128m
 > * standard_m128ms
 > * standard_m128ms_v2
 > * standard_m128s
 > * standard_m128s_v2
 > * standard_m16-4ms
 > * standard_m16-8ms
 > * standard_m16ms
 > * standard_m192idms_v2
 > * standard_m192ids_v2
 > * standard_m192ims_v2
 > * standard_m192is_v2
 > * standard_m208ms_v2
 > * standard_m208s_v2
 > * standard_m32-16ms
 > * standard_m32-8ms
 > * standard_m32dms_v2
 > * standard_m32ls
 > * standard_m32ms
 > * standard_m32ms_v2
 > * standard_m32ts
 > * standard_m416-208ms_v2
 > * standard_m416-208s_v2
 > * standard_m416ms_v2
 > * standard_m416s_v2
 > * standard_m64
 > * standard_m64-16ms
 > * standard_m64-32ms
 > * standard_m64dms_v2
 > * standard_m64ds_v2
 > * standard_m64ls
 > * standard_m64m
 > * standard_m64ms
 > * standard_m64ms_v2
 > * standard_m64s
 > * standard_m64s_v2
 > * standard_m8-2ms
 > * standard_m8-4ms
 > * standard_m8ms
 > * standard_nc12s_v3
 > * standard_nc16as_t4_v3
 > * standard_nc24rs_v3
 > * standard_nc24s_v3
 > * standard_nc4as_t4_v3
 > * standard_nc64as_t4_v3
 > * standard_nc6s_v3
 > * standard_nc8as_t4_v3
 > * standard_nv12s_v3
 > * standard_nv24s_v3
 > * standard_nv48s_v3

</details></blockquote>