### PR TITLE
Improve identifier generation

### DIFF
--- a/task/common/identifier.go
+++ b/task/common/identifier.go
@@ -15,21 +15,20 @@ type Identifier string
 
 const (
 	maximumLongLength = 50
-	shortLength = 16
+	shortLength       = 16
 )
 
 func (i Identifier) Long() string {
 	re := regexp.MustCompile(`(?s)^tpi-([a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?)-([a-z0-9]+)-([a-z0-9]+)$`)
 
-	if match := re.FindStringSubmatch(string(i));
-	   len(match) > 0 && hash(match[1]+match[2], shortLength / 2) == match[3] {
+	if match := re.FindStringSubmatch(string(i)); len(match) > 0 && hash(match[1]+match[2], shortLength/2) == match[3] {
 		return match[0]
 	}
 
-	name := normalize(string(i), maximumLongLength - shortLength - uint32(len("tpi---")))
-	digest := hash(string(i), shortLength / 2)
+	name := normalize(string(i), maximumLongLength-shortLength-uint32(len("tpi---")))
+	digest := hash(string(i), shortLength/2)
 
-	return fmt.Sprintf("tpi-%s-%s-%s", name, digest, hash(name+digest, shortLength / 2))
+	return fmt.Sprintf("tpi-%s-%s-%s", name, digest, hash(name+digest, shortLength/2))
 }
 
 func (i Identifier) Short() string {
@@ -44,7 +43,7 @@ func hash(identifier string, size uint8) string {
 	random := uid.NewRandCustom(bytes.NewReader(digest[:]))
 	encoder := uid.NewEncoderBase36()
 	provider := uid.NewProviderCustom(sha256.Size, random, encoder)
-	result :=  provider.MustGenerate().String()
+	result := provider.MustGenerate().String()
 
 	if len(result) < int(size) {
 		panic("not enough bytes to satisfy requested size")

--- a/task/common/identifier.go
+++ b/task/common/identifier.go
@@ -13,17 +13,23 @@ import (
 
 type Identifier string
 
+const (
+	maximumLongLength = 50
+	shortLength = 16
+)
+
 func (i Identifier) Long() string {
 	re := regexp.MustCompile(`(?s)^tpi-([a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?)-([a-z0-9]+)-([a-z0-9]+)$`)
 
-	if match := re.FindStringSubmatch(string(i)); len(match) > 0 && hash(match[1]+match[2], 4) == match[3] {
+	if match := re.FindStringSubmatch(string(i));
+	   len(match) > 0 && hash(match[1]+match[2], shortLength / 2) == match[3] {
 		return match[0]
 	}
 
-	name := normalize(string(i), 30)
-	digest := hash(string(i), 4)
+	name := normalize(string(i), maximumLongLength - shortLength - uint32(len("tpi---")))
+	digest := hash(string(i), shortLength / 2)
 
-	return fmt.Sprintf("tpi-%s-%s-%s", name, digest, hash(name+digest, 4))
+	return fmt.Sprintf("tpi-%s-%s-%s", name, digest, hash(name+digest, shortLength / 2))
 }
 
 func (i Identifier) Short() string {
@@ -33,13 +39,18 @@ func (i Identifier) Short() string {
 
 // hash deterministically generates a Base36 digest of `size`
 // characters using `identifier` as the seed.
-func hash(identifier string, size uint32) string {
+func hash(identifier string, size uint8) string {
 	digest := sha256.Sum256([]byte(identifier))
 	random := uid.NewRandCustom(bytes.NewReader(digest[:]))
 	encoder := uid.NewEncoderBase36()
-	provider := uid.NewProviderCustom(size, random, encoder)
+	provider := uid.NewProviderCustom(sha256.Size, random, encoder)
+	result :=  provider.MustGenerate().String()
 
-	return provider.MustGenerate().String()
+	if len(result) < int(size) {
+		panic("not enough bytes to satisfy requested size")
+	}
+
+	return result[:size]
 }
 
 // normalize normalizes user-provided identifiers by adapting them to

--- a/task/common/identifier.go
+++ b/task/common/identifier.go
@@ -20,7 +20,7 @@ func (i Identifier) Long() string {
 		return match[0]
 	}
 
-	name := normalize(string(i), 50)
+	name := normalize(string(i), 30)
 	digest := hash(string(i), 4)
 
 	return fmt.Sprintf("tpi-%s-%s-%s", name, digest, hash(name+digest, 4))
@@ -48,13 +48,10 @@ func normalize(identifier string, truncate uint32) string {
 	lowercase := strings.ToLower(identifier)
 
 	normalized := regexp.MustCompile("[^a-z0-9]+").ReplaceAllString(lowercase, "-")
-	normalized = regexp.MustCompile("(^-)|(-$)").ReplaceAllString(normalized, "")
 
 	if len(normalized) > int(truncate) {
 		normalized = normalized[:truncate]
 	}
 
-	return normalized
+	return regexp.MustCompile("(^-)|(-$)").ReplaceAllString(normalized, "")
 }
-
-// func NormalizeIdentifier(identifier common.Identifier, long bool) string {

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestIdentifier(t *testing.T) {
 	name := gofakeit.NewCrypto().Sentence(512)
 

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+)
+
+
+func TestIdentifier(t *testing.T) {
+	faker := gofakeit.NewCrypto()
+
+	t.Run("idempotency", func(t *testing.T) {
+		for count := 0; count < 1000; count++ {
+			value := faker.Sentence(512)
+			once := Identifier(value).Long()
+			twice := Identifier(once).Long()
+			require.Equal(t, once, twice)
+		}
+	})
+
+	t.Run("stability", func(t *testing.T) {
+		value := faker.Sentence(512)
+		sample := Identifier(value)
+		longSample := Identifier(value).Long()
+		shortSample := Identifier(value).Short()
+		for count := 0; count < 1000; count++ {
+			require.Equal(t, longSample, sample.Long())
+			require.Equal(t, shortSample, sample.Short())
+			require.Equal(t, longSample, Identifier(value).Long())
+			require.Equal(t, shortSample, Identifier(value).Short())
+		}
+	})
+
+	t.Run("homogeneity", func(t *testing.T) {
+		for count := 0; count < 1000; count++ {
+			value := faker.Sentence(512)
+
+			identifier := Identifier(value)
+			long := identifier.Long()
+			short := identifier.Short()
+
+			require.Regexp(t, "^tpi-[a-z0-9-]+$", long)
+			require.Regexp(t, "^[a-z0-9]+$", short)
+
+			require.LessOrEqual(t, len(long), 50)
+			require.LessOrEqual(t, len(short), 24)
+		}
+	})
+}

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -35,14 +35,14 @@ func TestIdentifier(t *testing.T) {
 		require.Regexp(t, "^tpi-[a-z0-9-]+$", long)
 		require.Regexp(t, "^[a-z0-9]+$", short)
 
-		require.LessOrEqual(t, len(long), 50)
-		require.LessOrEqual(t, len(short), 24)
+		require.LessOrEqual(t, len(long), maximumLongLength)
+		require.Equal(t, len(short), shortLength)
 	})
 
 	t.Run("compatibility", func(t *testing.T) {
 		identifier := Identifier("test")
 
-		require.Equal(t, identifier.Long(), "tpi-test-189gt4x-1q5wad0")
-		require.Equal(t, identifier.Short(), "189gt4x1q5wad0")
+		require.Equal(t, "tpi-test-3z4xlzwq-3u0vweb4", identifier.Long())
+		require.Equal(t, "3z4xlzwq3u0vweb4", identifier.Short())
 	})
 }

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -9,43 +9,40 @@ import (
 
 
 func TestIdentifier(t *testing.T) {
-	faker := gofakeit.NewCrypto()
+	name := gofakeit.NewCrypto().Sentence(512)
 
-	t.Run("idempotency", func(t *testing.T) {
-		for count := 0; count < 1000; count++ {
-			value := faker.Sentence(512)
-			once := Identifier(value).Long()
-			twice := Identifier(once).Long()
-			require.Equal(t, once, twice)
-		}
+	t.Run("idempotence", func(t *testing.T) {
+		identifier := Identifier(name)
+
+		once := identifier.Long()
+		twice := Identifier(once).Long()
+		require.Equal(t, once, twice)
 	})
 
 	t.Run("stability", func(t *testing.T) {
-		value := faker.Sentence(512)
-		sample := Identifier(value)
-		longSample := Identifier(value).Long()
-		shortSample := Identifier(value).Short()
-		for count := 0; count < 1000; count++ {
-			require.Equal(t, longSample, sample.Long())
-			require.Equal(t, shortSample, sample.Short())
-			require.Equal(t, longSample, Identifier(value).Long())
-			require.Equal(t, shortSample, Identifier(value).Short())
-		}
+		identifier := Identifier(name)
+
+		require.Equal(t, identifier.Long(), identifier.Long())
+		require.Equal(t, identifier.Short(), identifier.Short())
 	})
 
 	t.Run("homogeneity", func(t *testing.T) {
-		for count := 0; count < 1000; count++ {
-			value := faker.Sentence(512)
+		identifier := Identifier(name)
 
-			identifier := Identifier(value)
-			long := identifier.Long()
-			short := identifier.Short()
+		long := identifier.Long()
+		short := identifier.Short()
 
-			require.Regexp(t, "^tpi-[a-z0-9-]+$", long)
-			require.Regexp(t, "^[a-z0-9]+$", short)
+		require.Regexp(t, "^tpi-[a-z0-9-]+$", long)
+		require.Regexp(t, "^[a-z0-9]+$", short)
 
-			require.LessOrEqual(t, len(long), 50)
-			require.LessOrEqual(t, len(short), 24)
-		}
+		require.LessOrEqual(t, len(long), 50)
+		require.LessOrEqual(t, len(short), 24)
+	})
+
+	t.Run("compatibility", func(t *testing.T) {
+		identifier := Identifier("test")
+
+		require.Equal(t, identifier.Long(), "tpi-test-189gt4x-1q5wad0")
+		require.Equal(t, identifier.Short(), "189gt4x1q5wad0")
 	})
 }


### PR DESCRIPTION
Unless proven otherwise, the creation of different identifiers for the same input string is not possible.

Closes #298