### PR TITLE
Handle GPG keys without intermediate GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,15 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      - uses: paultyng/ghaction-import-gpg@v2.1.0        
+      - run: |
+          gpg --import <<< "$TERRAFORM_REGISTRY_GPG_PRIVATE_KEY"
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
-        id: import_gpg
+          TERRAFORM_REGISTRY_GPG_PRIVATE_KEY: ${{ secrets.TERRAFORM_REGISTRY_GPG_PRIVATE_KEY }}
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
         env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   synchronize:
     # Empyrically equivalent to pressing the "Resync" button in the Settings
@@ -46,5 +44,5 @@ jobs:
         END
     - run: |
         while ! terraform init; do
-            sleep $((2**++try))
+          sleep $((2**++try))
         done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,6 @@ signs:
       # if you are using this is a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"
       - "${signature}"
       - "--detach-sign"


### PR DESCRIPTION
Coming from https://github.com/iterative/terraform-provider-iterative/pull/285#pullrequestreview-817110372, should work as-is, although it hasn't been tested yet.