### PR TITLE
Stop machines if task script fails

### DIFF
--- a/task/common/machine/script.go
+++ b/task/common/machine/script.go
@@ -47,7 +47,7 @@ sudo tee /etc/systemd/system/tpi-task.service > /dev/null <<END
 [Service]
   Type=simple
   ExecStart=/usr/bin/tpi-task
-  ExecStop=/bin/bash -c 'systemctl is-system-running | grep stopping || tpi --stop'
+  ExecStopPost=/bin/bash -c 'systemctl is-system-running | grep stopping || tpi --stop'
   EnvironmentFile=/tmp/tpi-environment
   WorkingDirectory=/tmp/tpi-task
   TimeoutStartSec=%s


### PR DESCRIPTION
Machines weren't being stopped unless the task script finished with a zero exit code.

### Relevant documentation from [`systemd.service(5)`](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

#### `ExecStop=`

> [...] _Note that the commands specified in `ExecStop=` are only executed when the service started successfully first. They are not invoked if the service was never started at all, or in case its start-up failed, for example because any of the commands specified in `ExecStart=`_ [...] _failed_ [...] _or timed out. Use `ExecStopPost=` to invoke commands when a service failed to start up correctly and is shut down again. Also note that the stop operation is always performed if the service started successfully, even if the processes in the service terminated on their own or were killed. The stop commands must be prepared to deal with that case._ [...] _For post-mortem clean-up steps use `ExecStopPost=` instead._

#### `ExecStopPost=`

> _Additional commands that are executed after the service is stopped. This includes cases where_ [...] _the service exited unexpectedly._ [...] _Note that – unlike `ExecStop=` – commands specified with this setting are invoked when a service failed to start up correctly and is shut down again._ [...] _It is recommended to use this setting for clean-up operations that shall be executed even when the service failed to start up correctly._

Bug spotted by @MKhalusova