### PR TITLE
GCP auth logic

### DIFF
--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"terraform-provider-iterative/iterative/utils"
+
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	gcp_compute "google.golang.org/api/compute/v1"
@@ -289,7 +291,7 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 	var credentials *google.Credentials
 	var err error
 
-	if credentialsData := []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_DATA")); len(credentialsData) > 0 {
+	if credentialsData := []byte(utils.LoadGCPCredentials()); len(credentialsData) > 0 {
 		credentials, err = google.CredentialsFromJSON(oauth2.NoContext, credentialsData, gcp_compute.ComputeScope)
 	} else {
 		credentials, err = google.FindDefaultCredentials(oauth2.NoContext, gcp_compute.ComputeScope)

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -431,7 +431,7 @@ func provisionerCode(d *schema.ResourceData) (string, error) {
 	data["AZURE_CLIENT_SECRET"] = os.Getenv("AZURE_CLIENT_SECRET")
 	data["AZURE_SUBSCRIPTION_ID"] = os.Getenv("AZURE_SUBSCRIPTION_ID")
 	data["AZURE_TENANT_ID"] = os.Getenv("AZURE_TENANT_ID")
-	data["GOOGLE_APPLICATION_CREDENTIALS_DATA"] = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_DATA")
+	data["GOOGLE_APPLICATION_CREDENTIALS_DATA"] = utils.LoadGCPCredentials()
 	data["KUBERNETES_CONFIGURATION"] = os.Getenv("KUBERNETES_CONFIGURATION")
 	data["container"] = isContainerAvailable(d.Get("cloud").(string))
 	data["setup"] = strings.Replace(string(setup[:]), "#/bin/sh", "", 1)

--- a/iterative/utils/helpers.go
+++ b/iterative/utils/helpers.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+
 	"github.com/aohorodnyk/uid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -30,4 +32,16 @@ func StripAvailabilityZone(region string) string {
 		return region[:len(region)-1]
 	}
 	return region
+}
+
+func LoadGCPCredentials() string {
+	credentialsData := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_DATA")
+	if len(credentialsData) == 0 {
+		credentialsPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+		if len(credentialsPath) > 0 {
+			jsonData, _ := os.ReadFile(credentialsPath)
+			credentialsData = string(jsonData)
+		}
+	}
+	return credentialsData
 }


### PR DESCRIPTION
An interesting find from: https://github.com/iterative/cml/issues/834 
@eemelipa thank you for the help, I was worried I introduced a new bug! 😮‍💨 

TPI grabs the GCP credentials from here: https://github.com/iterative/terraform-provider-iterative/blob/66bc9cd08a4ef1b17f068ce7fd296c3065a6c810/iterative/gcp/provider.go#L292-L296

In this case, the user set their [GCP SA creds](https://cml.dev/doc/self-hosted-runners?tab=GCP#cloud-compute-resource-credentials) with the `GOOGLE_APPLICATION_CREDENTIALS`  which is a path to the JSON file which the above code finds via the else clause: https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials

so the `cml runner` successfully ran from the invoked system but the cml.sh did not get the creds for termination because the template only refs the json env https://github.com/iterative/terraform-provider-iterative/blob/66bc9cd08a4ef1b17f068ce7fd296c3065a6c810/iterative/resource_runner.go#L434 and https://github.com/iterative/terraform-provider-iterative/blob/66bc9cd08a4ef1b17f068ce7fd296c3065a6c810/iterative/resource_runner.go#L319

If `GOOGLE_APPLICATION_CREDENTIALS_DATA` is empty check `GOOGLE_APPLICATION_CREDENTIALS` and if present read the file to populate back as `GOOGLE_APPLICATION_CREDENTIALS_DATA` for cml.sh consistency.