### PR TITLE
Delete task resources when creation fails

### DIFF
--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -2,6 +2,7 @@ package iterative
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -146,10 +147,11 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	if err := task.Create(ctx); err != nil {
 		diags = diagnostic(diags, err, diag.Error)
-		if err := task.Delete(ctx); err != nil {
+		if err := task.Delete(ctx); err == nil {
+			diags = diagnostic(diags, errors.New("deleted all the remaining resources"), diag.Warning)
+		} else {
 			diags = diagnostic(diags, err, diag.Error)
 		}
-		return diags
 	}
 
 	d.SetId(task.GetIdentifier(ctx).Long())

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -145,7 +145,11 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 	}
 
 	if err := task.Create(ctx); err != nil {
-		return diagnostic(diags, err, diag.Error)
+		diags = diagnostic(diags, err, diag.Error)
+		if err := task.Delete(ctx); err != nil {
+			diags = diagnostic(diags, err, diag.Error)
+		}
+		return diags
 	}
 
 	d.SetId(task.GetIdentifier(ctx).Long())


### PR DESCRIPTION
Indirectly closes #314 and mitigates a heap of different issues; ~requires manual testing on actual infrastructure. I'll script something later today to deplete my S3 quota~ tested and working.