### PR TITLE
Allow custom machine+gpu*count on runner cloud=gcp

### DIFF
--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -441,7 +441,18 @@ func getInstanceType(instanceType string, instanceGPU string) (map[string]map[st
 		},
 	}
 
-	if val, ok := instanceTypes[instanceType+"+"+instanceGPU]; ok {
+	match := regexp.MustCompile(`^([^+]+)\+([^*]+)\*([1-9]\d*)?$`).FindStringSubmatch(instanceType)
+	if match != nil {
+		return map[string]map[string]string{
+			"accelerator": {
+				"count": match[3],
+				"type":  match[2],
+			},
+			"machine": {
+				"type": match[1],
+			},
+		}, nil
+	} else if val, ok := instanceTypes[instanceType+"+"+instanceGPU]; ok {
 		return val, nil
 	} else if val, ok := instanceTypes[instanceType]; ok && instanceGPU == "" {
 		return val, nil


### PR DESCRIPTION
This pull request allows `iterative_machine` and `iterative_cml_runner` users to specify custom `machine+accelerator*count` combinations (e.g. `custom-8-53248+nvidia-tesla-k80*1`) with the same syntax as the `iterative_task` resource. [(Discord)](https://discord.com/channels/485586884165107732/728693131557732403/938190175224348752)