### PR TITLE
Avoid taint on apply error

### DIFF
--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -162,16 +162,17 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diagnostic(diags, err, diag.Error)
 	}
 
-	if err := task.Create(ctx); err != nil {
+	if err := task.Create(ctx); err == nil {
+		d.SetId(task.GetIdentifier(ctx).Long())
+	} else {
 		diags = diagnostic(diags, err, diag.Error)
 		if err := task.Delete(ctx); err == nil {
-			diags = diagnostic(diags, errors.New("deleted all the remaining resources"), diag.Warning)
+			diags = diagnostic(diags, errors.New("failed to create"), diag.Error)
 		} else {
 			diags = diagnostic(diags, err, diag.Error)
 		}
-	}
+	} 
 
-	d.SetId(task.GetIdentifier(ctx).Long())
 	return
 }
 

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -171,7 +171,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 		} else {
 			diags = diagnostic(diags, err, diag.Error)
 		}
-	} 
+	}
 
 	return
 }


### PR DESCRIPTION
When `terraform apply` failed, the state file still retained a copy of the resource, and subsequent runs had no effect. 🙈  

```json
{
  ···
  "resources": [
    {
      ···
      "instances": [
        {
          "status": "tainted",
          ···
        }
      ]
    }
  ]
}
```