### PR TITLE
Add NVIDIA NGC image aliases

### DIFF
--- a/task/aws/resources/data_source_image.go
+++ b/task/aws/resources/data_source_image.go
@@ -34,6 +34,7 @@ func (i *Image) Read(ctx context.Context) error {
 	image := i.Identifier
 	images := map[string]string{
 		"ubuntu": "ubuntu@099720109477:x86_64:*ubuntu/images/hvm-ssd/ubuntu-focal-20.04*",
+		"nvidia": "ubuntu@679593333241:x86_64:NVIDIA Deep Learning  AMI v21.02.2-*",
 	}
 	if val, ok := images[image]; ok {
 		image = val

--- a/task/az/resources/resource_virtual_machine_scale_set.go
+++ b/task/az/resources/resource_virtual_machine_scale_set.go
@@ -82,12 +82,13 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 	image := v.Attributes.Environment.Image
 	images := map[string]string{
 		"ubuntu": "ubuntu@Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest",
+		"nvidia": "ubuntu@nvidia:ngc_base_image_version_b:gen2_21-11-0:latest#plan",
 	}
 	if val, ok := images[image]; ok {
 		image = val
 	}
 
-	imageParts := regexp.MustCompile(`^([^@]+)@([^:]+):([^:]+):([^:]+):([^:]+)$`).FindStringSubmatch(image)
+	imageParts := regexp.MustCompile(`^([^@]+)@([^:]+):([^:]+):([^:]+):([^:]+)(:?(#plan)?)$`).FindStringSubmatch(image)
 	if imageParts == nil {
 		return errors.New("invalid machine image format: use publisher:offer:sku:version")
 	}
@@ -97,6 +98,7 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 	offer := imageParts[3]
 	sku := imageParts[4]
 	version := imageParts[5]
+	plan := imageParts[6]
 
 	size := v.Attributes.Size.Machine
 	sizes := map[string]string{
@@ -182,6 +184,14 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 					},
 				},
 			},
+		},
+	}
+
+	if plan == "#plan" {
+		settings.Plan = &compute.Plan{
+			Publisher: to.StringPtr(publisher),
+			Product:   to.StringPtr(offer),
+			Name:      to.StringPtr(sku),
 		},
 	}
 

--- a/task/az/resources/resource_virtual_machine_scale_set.go
+++ b/task/az/resources/resource_virtual_machine_scale_set.go
@@ -192,7 +192,7 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 			Publisher: to.StringPtr(publisher),
 			Product:   to.StringPtr(offer),
 			Name:      to.StringPtr(sku),
-		},
+		}
 	}
 
 	spot := v.Attributes.Spot

--- a/task/gcp/resources/data_source_image.go
+++ b/task/gcp/resources/data_source_image.go
@@ -51,16 +51,16 @@ func (i *Image) Read(ctx context.Context) error {
 	if err != nil {
 		var e *googleapi.Error
 		if errors.As(err, &e) && e.Code == 404 {
-				resource, err := i.Client.Services.Compute.Images.GetFromFamily(project, imageOrFamily).Do()
-				if err != nil {
-					var e *googleapi.Error
-					if errors.As(err, &e) && e.Code == 404 {
-						return common.NotFoundError
-					}
-					return err
+			resource, err := i.Client.Services.Compute.Images.GetFromFamily(project, imageOrFamily).Do()
+			if err != nil {
+				var e *googleapi.Error
+				if errors.As(err, &e) && e.Code == 404 {
+					return common.NotFoundError
 				}
-				i.Resource = resource
-				return nil
+				return err
+			}
+			i.Resource = resource
+			return nil
 		}
 		return err
 	}

--- a/task/gcp/resources/data_source_image.go
+++ b/task/gcp/resources/data_source_image.go
@@ -32,6 +32,7 @@ func (i *Image) Read(ctx context.Context) error {
 	image := i.Identifier
 	images := map[string]string{
 		"ubuntu": "ubuntu@ubuntu-os-cloud/ubuntu-2004-lts",
+		"nvidia": "ubuntu@nvidia-ngc-public/nvidia-gpu-cloud-image-20211105",
 	}
 	if val, ok := images[image]; ok {
 		image = val
@@ -39,18 +40,27 @@ func (i *Image) Read(ctx context.Context) error {
 
 	match := regexp.MustCompile(`^([^@]+)@([^/]+)/([^/]+)$`).FindStringSubmatch(image)
 	if match == nil {
-		return common.NotFoundError
+		return errors.New("wrong image name")
 	}
 
 	i.Attributes.SSHUser = match[1]
 	project := match[2]
-	family := match[3]
+	imageOrFamily := match[3]
 
-	resource, err := i.Client.Services.Compute.Images.GetFromFamily(project, family).Do()
+	resource, err := i.Client.Services.Compute.Images.Get(project, imageOrFamily).Do()
 	if err != nil {
 		var e *googleapi.Error
 		if errors.As(err, &e) && e.Code == 404 {
-			return common.NotFoundError
+				resource, err := i.Client.Services.Compute.Images.GetFromFamily(project, imageOrFamily).Do()
+				if err != nil {
+					var e *googleapi.Error
+					if errors.As(err, &e) && e.Code == 404 {
+						return common.NotFoundError
+					}
+					return err
+				}
+				i.Resource = resource
+				return nil
 		}
 		return err
 	}

--- a/task/k8s/resources/resource_job.go
+++ b/task/k8s/resources/resource_job.go
@@ -68,9 +68,17 @@ func (j *Job) Create(ctx context.Context) error {
 		"l+v100":  "32-256000+nvidia-tesla-v100*4",
 		"xl+v100": "64-512000+nvidia-tesla-v100*8",
 	}
-
 	if val, ok := sizes[size]; ok {
 		size = val
+	}
+
+	image := j.Attributes.Task.Environment.Image
+	images := map[string]string{
+		"ubuntu": "ubuntu",
+		"nvidia": "nvidia/cuda",
+	}
+	if val, ok := images[image]; ok {
+		image = val
 	}
 
 	match := regexp.MustCompile(`^(\d+)-(\d+)(?:\+([^*]+)\*([1-9]\d*))?$`).FindStringSubmatch(size)
@@ -206,7 +214,7 @@ func (j *Job) Create(ctx context.Context) error {
 					Containers: []kubernetes_core.Container{
 						{
 							Name:  j.Identifier,
-							Image: j.Attributes.Task.Environment.Image,
+							Image: image,
 							Resources: kubernetes_core.ResourceRequirements{
 								Limits: jobLimits,
 								Requests: kubernetes_core.ResourceList{


### PR DESCRIPTION
[NVIDIA NGC](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud) offers machine and container images with **GPU drivers** and **Docker with GPU support** out of the box for [`aws`](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-aws/#ami-overview), [`az`](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/#overview), [`gcp`](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-gcp/index.html#overview), [`k8s`](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-deploy-containers/index.html) and other platforms.

We are “maintaining” custom AWS machine images (https://github.com/iterative/terraform-provider-iterative/pull/206) that offer the same packages, plus Node.js for running the CML source distribution. After [cml#825](https://github.com/iterative/cml/issues/825) we don't need Node.js anymore, and it makes more sense to use NVIDIA images instead of publishing our own.

#### Related
* https://github.com/iterative/terraform-provider-iterative/issues/174
* https://github.com/iterative/dvc.org/pull/3246
* https://github.com/iterative/dvc.org/pull/3087

## Example

```hcl
resource "iterative_task" "example" {
  name  = "example"
  cloud = "aws"

  machine   = "m+v100"
  disk_size = "32"
  image     = "nvidia"

  script = <<-END
    #!/bin/sh
    nvidia-smi
    docker -v
  END
}
```

> 📖 _Note that the default disk size (30 GB) is not enough for most of these images; it should be explicitly increased._

## Versions

#### `aws`

```console
$ aws ec2 describe-images --region=us-east-1 --owners=aws-marketplace --filter=Name=name,Values="NVIDIA*"
{
    "Images": [
        {
            "Architecture": "x86_64",
            "OwnerId": "679593333241",
            "Name": "NVIDIA Deep Learning  AMI v21.02.2-46a68101-e56b-41cd-8e32-631ac6e5d02b",
            "ProductCodes": [
                {
                    "ProductCodeId": "46kqvw7d9nbo0v2bfgi8z26gb",
                    "ProductCodeType": "marketplace"
                }
            ],
            ...
        },
        ...
    ]
}
```

```hcl
image = "ubuntu@679593333241:x86_64:NVIDIA Deep Learning  AMI v21.02.2-46a68101-e56b-41cd-8e32-631ac6e5d02b"
```

> 📖 _Visit https://aws.amazon.com/marketplace/pp?sku=46kqvw7d9nbo0v2bfgi8z26gb to accept terms and subscribe._

#### `az`

```console
$ az vm image list --publisher=nvidia --all
[
  {
    "offer": "ngc_base_image_version_b",
    "publisher": "nvidia",
    "sku": "gen2_21-11-0",
    "urn": "nvidia:ngc_base_image_version_b:gen2_21-11-0:21.11.0",
    "version": "21.11.0"
  },
  ...
]
```

```hcl
image = "ubuntu@nvidia:ngc_base_image_version_b:gen2_21-11-0:21.11.0#plan"
```

> 📖  _Run the following [`az`](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest) command to [accept the image terms](https://docs.microsoft.com/en-us/cli/azure/vm/image/terms?view=azure-cli-latest):_
> 
> ```console
> az vm image terms accept --urn nngc_base_image_version_b:gen2_21-06-0:21.06.0
> ```

#### `gcp`

```console
$ gcloud compute images list --project=nvidia-ngc-public --filter=name~nvidia-gpu-cloud
NAME                                               PROJECT            FAMILY  DEPRECATED  STATUS
nvidia-gpu-cloud-image-20211105                    nvidia-ngc-public                      READY
...
```

```hcl
image = "ubuntu@nvidia-ngc-public/nvidia-gpu-cloud-image-20211105"
```

<blockquote>

⚠️ _Drivers don't work out of the box because they require a manual reboot to finish the installation._
<details><summary>Gory details...</summary>
When logging in with an interactive shell, the following message is displayed:
<pre>
NVIDIA GPU Cloud (NGC) is an optimized software environment that requires the
latest NVIDIA drivers to operate. If you do not download the NVIDIA drivers at
this time, your instance will shut down. Would you like to download the latest
NVIDIA drivers so NGC can finish installing? (Y/n)
</pre>

<!-- ![Linus_Torvalds_Linux_Nvidia_middle_finger-1380653 copia](https://user-images.githubusercontent.com/11387611/152889584-6a29ff4a-ae19-44f4-b0d0-93e25266fb30.png) -->

See https://gist.github.com/eliask/cd14372aabcb871aaaa661a87e2a2b2d for some workarounds.

</details>
</blockquote>

#### `k8s`

Example for the  [`nvidia/cuda:11.6.0-runtime-ubuntu20.04`](https://hub.docker.com/layers/nvidia/cuda/11.6.0-runtime-ubuntu20.04/images/sha256-70df05504934e38bec692f9f50365fdf66219d0f036619d1aa7c83dc0ee3024b?context=explore) tag:

```hcl
image = "nvidia/cuda:11.6.0-runtime-ubuntu20.04
```

See https://hub.docker.com/r/nvidia/cuda for a comprehensive list of tags.