### PR TITLE
Separate input and output directory settings

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -23,6 +23,7 @@ resource "iterative_task" "task" {
   cloud = "aws" # or any of: gcp, az, k8s
   workdir {
     input = "${path.root}/shared"
+    output = "${path.root}/shared"
   }
   script = <<-END
     #!/bin/bash

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -43,7 +43,7 @@ resource "iterative_task" "task" {
 - `image` - (Optional) [Machine image](#machine-images) to run the task with.
 - `parallelism` - (Optional) Number of machines to be launched in parallel.
 - `workdir.input` - (Optional) Local working directory to upload.
-- `workdir.output` - (Optional) Local directory to download results to (default: `workdir.input`).
+- `workdir.output` - (Optional) Local directory to download results to.
 - `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. Empty values may also be combined with a [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) name to import all matching variables.
 - `timeout` - (Optional) Maximum number of seconds to run before termination.
 

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -43,7 +43,7 @@ resource "iterative_task" "task" {
 - `image` - (Optional) [Machine image](#machine-images) to run the task with.
 - `parallelism` - (Optional) Number of machines to be launched in parallel.
 - `workdir.input` - (Optional) Local working directory to upload.
-- `workdir.output` - (Optional) Local directory to download results to.
+- `workdir.output` - (Optional) Local directory to download results to (default: no download).
 - `environment` - (Optional) Map of environment variable names and values for the task script. Empty string values are replaced with local environment values. Empty values may also be combined with a [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) name to import all matching variables.
 - `timeout` - (Optional) Maximum number of seconds to run before termination.
 

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -289,9 +289,6 @@ func resourceTaskBuild(ctx context.Context, d *schema.ResourceData, m interface{
 			return nil, errors.New("output directory " + directory_out + " is not empty!")
 		}
 	}
-	if directory_out == "" {
-		directory_out = directory
-	}
 
 	t := common.Task{
 		Size: common.Size{


### PR DESCRIPTION
## Follow-up of #340, 
 - closes #303

### Old behavior

When `output` was unset, `""` or `null` it implicitly mirrored the value of `input`.

```hcl
resource "iterative_task" "example" {
  ···
  workdir {
    input = "/path/to/input"
    # output = "/path/to/input" is implicit
  }
}
```

### New behavior

When `output` is unset, `""` or `null` it will be disabled. Doesn't implicitly take the value of `input` anymore.

```hcl
resource "iterative_task" "example" {
  ···
  workdir {
    input = "/path/to/input"
    output = "/path/to/output"
  }
}
```