### PR TITLE
Allow for specify scopes for assigned service account

### DIFF
--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -301,7 +301,7 @@ func getServiceAccountData(saString string) (string, []string) {
 	splitStr[1] = strings.Split(splitStr[1], "=")[1]
 	// ["s1", "s2", ...]
 	serviceAccountScopes := splitStr[1:]
-	return serviceAccountEmail, serviceAccountScopes
+	return serviceAccountEmail, utils.CanonicalizeServiceScopes(serviceAccountScopes)
 }
 
 func getProjectService() (string, *gcp_compute.Service, error) {

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -295,10 +295,10 @@ func getServiceAccountData(saString string) (string, []string) {
 	serviceAccountEmail := splitStr[0]
 	if len(splitStr) == 1 {
 		// warn user about scopes?
-		return serviceAccountEmail, []string{""}
+		return serviceAccountEmail, nil
 	}
 	// ["scopes", "s1"]
-	splitStr[1] = strings.Split(splitStr[1], "0")[1]
+	splitStr[1] = strings.Split(splitStr[1], ",")[1]
 	// ["s1", "s2", ...]
 	serviceAccountScopes := splitStr[1:]
 	return serviceAccountEmail, serviceAccountScopes

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -297,8 +297,8 @@ func getServiceAccountData(saString string) (string, []string) {
 		// warn user about scopes?
 		return serviceAccountEmail, nil
 	}
-	// ["scopes", "s1"]
-	splitStr[1] = strings.Split(splitStr[1], ",")[1]
+	// ["scopes=s1", "s2"]
+	splitStr[1] = strings.Split(splitStr[1], "=")[1]
 	// ["s1", "s2", ...]
 	serviceAccountScopes := splitStr[1:]
 	return serviceAccountEmail, serviceAccountScopes

--- a/iterative/utils/helpers.go
+++ b/iterative/utils/helpers.go
@@ -37,3 +37,47 @@ func LoadGCPCredentials() string {
 	}
 	return credentialsData
 }
+
+// Better way than copying?
+// https://github.com/hashicorp/terraform-provider-google/blob/8a362008bd4d36b6a882eb53455f87305e6dff52/google/service_scope.go#L5-L48
+func canonicalizeServiceScope(scope string) string {
+	// This is a convenience map of short names used by the gcloud tool
+	// to the GCE auth endpoints they alias to.
+	scopeMap := map[string]string{
+		"bigquery":              "https://www.googleapis.com/auth/bigquery",
+		"cloud-platform":        "https://www.googleapis.com/auth/cloud-platform",
+		"cloud-source-repos":    "https://www.googleapis.com/auth/source.full_control",
+		"cloud-source-repos-ro": "https://www.googleapis.com/auth/source.read_only",
+		"compute-ro":            "https://www.googleapis.com/auth/compute.readonly",
+		"compute-rw":            "https://www.googleapis.com/auth/compute",
+		"datastore":             "https://www.googleapis.com/auth/datastore",
+		"logging-write":         "https://www.googleapis.com/auth/logging.write",
+		"monitoring":            "https://www.googleapis.com/auth/monitoring",
+		"monitoring-read":       "https://www.googleapis.com/auth/monitoring.read",
+		"monitoring-write":      "https://www.googleapis.com/auth/monitoring.write",
+		"pubsub":                "https://www.googleapis.com/auth/pubsub",
+		"service-control":       "https://www.googleapis.com/auth/servicecontrol",
+		"service-management":    "https://www.googleapis.com/auth/service.management.readonly",
+		"sql":                   "https://www.googleapis.com/auth/sqlservice",
+		"sql-admin":             "https://www.googleapis.com/auth/sqlservice.admin",
+		"storage-full":          "https://www.googleapis.com/auth/devstorage.full_control",
+		"storage-ro":            "https://www.googleapis.com/auth/devstorage.read_only",
+		"storage-rw":            "https://www.googleapis.com/auth/devstorage.read_write",
+		"taskqueue":             "https://www.googleapis.com/auth/taskqueue",
+		"trace":                 "https://www.googleapis.com/auth/trace.append",
+		"useraccounts-ro":       "https://www.googleapis.com/auth/cloud.useraccounts.readonly",
+		"useraccounts-rw":       "https://www.googleapis.com/auth/cloud.useraccounts",
+		"userinfo-email":        "https://www.googleapis.com/auth/userinfo.email",
+	}
+	if matchedURL, ok := scopeMap[scope]; ok {
+		return matchedURL
+	}
+	return scope
+}
+func CanonicalizeServiceScopes(scopes []string) []string {
+	cs := make([]string, len(scopes))
+	for i, scope := range scopes {
+		cs[i] = canonicalizeServiceScope(scope)
+	}
+	return cs
+}


### PR DESCRIPTION
The `instance_permission_set` could read:
- `sa@***.iam.gserviceaccount.com` (I think this should through a warning from use, no scopes does nothing 🙈 )
- `sa@***.iam.gserviceaccount.com,scopes=https://www.googleapis.com/auth/cloud-platform`

or using gcp's shorthand linked below

- `sa@***.iam.gserviceaccount.com,scopes=storage-rw,cloud-source-repos`

Slight oversight in some fine print found here: https://cloud.google.com/iam/docs/service-accounts#access_scopes
> Google Cloud now uses IAM, not access scopes, to specify permissions for Compute Engine instances. However, you are still required to set an access scope when you configure an instance to impersonate a service account

Scopes/Shorthand for reference: https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes

From additional reading in order to function properly both the permissions on the SA and correct scope are required for applications running on the instance to "impersonate" the service account.

I'll add that when the `instance_permission_set` is used credentials used to invoke terraform or `cml runner` need the `Role` `Service Account User`