### PR TITLE
task docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Iterative Provider makes it easy to:
 - Rapidly move local machine learning experiments to a cloud infrastructure
 - Take advantage of training models on spot instances without losing any progress
 - Unify configuration of various cloud compute providers
-- Automatically destroy unused cloud resources (never forget to turn your GPU off again)
+- Automatically destroy unused cloud resources (compute instances are terminated on job completion/failure, and storage is removed when results are downloaded)
 
 The Iterative Provider can provision resources with the following cloud providers and orchestrators:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -37,7 +37,7 @@ resource "iterative_task" "task" {
 
 See [the reference](https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task) for a full list of options -- including more information on [`machine` types](https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#machine-type).
 
--> **Note:** The `script` argument must begin with a valid [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>). It can take a [heredoc string](https://www.terraform.io/docs/language/expressions/strings.html#heredoc-strings) or [a `file()` function](https://www.terraform.io/docs/language/functions/file.html) function (e.g. `file("task_run.sh")`).
+-> **Note:** The `script` argument must begin with a valid [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>), and can take the form of a [heredoc string](https://www.terraform.io/docs/language/expressions/strings.html#heredoc-strings) or [a `file()` function](https://www.terraform.io/docs/language/functions/file.html) function (e.g. `file("task_run.sh")`).
 
 The project layout should look similar to this:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -37,7 +37,7 @@ resource "iterative_task" "task" {
 
 See [the reference](https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task) for a full list of options -- including more information on [`machine` types](https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#machine-type).
 
--> **Note:** The `script` argument can take any string, including a [heredoc](https://www.terraform.io/docs/language/expressions/strings.html#heredoc-strings) or the contents of a file returned by the [`file`](https://www.terraform.io/docs/language/functions/file.html) function.
+-> **Note:** The `script` argument must begin with a valid [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>). It can take a [heredoc string](https://www.terraform.io/docs/language/expressions/strings.html#heredoc-strings) or [a `file()` function](https://www.terraform.io/docs/language/functions/file.html) function (e.g. `file("task_run.sh")`).
 
 The project layout should look similar to this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,11 +51,11 @@ See the [Azure documentation](https://docs.microsoft.com/en-us/python/api/azure-
 
 ### Google Cloud Platform
 
-- `GOOGLE_APPLICATION_CREDENTIALS` - Path to a [service account](https://cloud.google.com/iam/docs/service-accounts) JSON key file.
+- `GOOGLE_APPLICATION_CREDENTIALS` - Path to a service account JSON key file.
 
 -> **Note:** you can also use `GOOGLE_APPLICATION_CREDENTIALS_DATA` with the **contents** of the service account JSON key file.
 
-See the [summary of GCP credentials on the DVC site](https://dvc.org/doc/user-guide/setup-google-drive-remote#using-service-accounts) to get started quickly.
+See the [GCP documentation](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account) for more information.
 
 ### Kubernetes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ $ terraform apply
 - `AWS_SECRET_ACCESS_KEY` - Secret access key.
 - `AWS_SESSION_TOKEN` - (Optional) Session token.
 
+See the [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) for more information.
+
 ### Microsoft Azure
 
 - `AZURE_CLIENT_ID` - Client identifier.
@@ -45,11 +47,15 @@ $ terraform apply
 - `AZURE_SUBSCRIPTION_ID` - Subscription identifier.
 - `AZURE_TENANT_ID` - Tenant identifier.
 
+See the [Azure documentation](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential) for more information.
+
 ### Google Cloud Platform
 
-- `GOOGLE_APPLICATION_CREDENTIALS` - Path to a service account JSON key file.
+- `GOOGLE_APPLICATION_CREDENTIALS` - Path to a [service account](https://cloud.google.com/iam/docs/service-accounts) JSON key file.
 
 -> **Note:** you can also use `GOOGLE_APPLICATION_CREDENTIALS_DATA` with the **contents** of the service account JSON key file.
+
+See the [summary of GCP credentials on the DVC site](https://dvc.org/doc/user-guide/setup-google-drive-remote#using-service-accounts) to get started quickly.
 
 ### Kubernetes
 

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -30,7 +30,7 @@ resource "iterative_task" "task" {
 ### Required
 
 - `cloud` - (Required) Cloud provider to run the task on; valid values are `aws`, `gcp`, `az` and `k8s`.
-- `script` - (Required) Script to run; must begin with a valid [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>).
+- `script` - (Required) Script to run (relative to `workdir.input`); must begin with a valid [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>). Can use a string, including a [heredoc](https://www.terraform.io/docs/language/expressions/strings.html#heredoc-strings), or the contents of a file returned by the [`file`](https://www.terraform.io/docs/language/functions/file.html) function.
 
 ### Optional
 


### PR DESCRIPTION
- add links to authentication credentials docs
- explain "auto-destroy unused resources"
- explain `script` usage (heredoc, `file()`, relative to `workdir.input`)
