### PR TITLE
Move task tests to AWS sandbox (OIDC)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,6 @@
 name: Smoke Test
+permissions:
+  id-token: write
 on:
   pull_request_target:
     paths: 'task/**'
@@ -19,9 +21,6 @@ jobs:
       matrix:
         provider: [AWS, AZ, GCP]
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -35,6 +34,11 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ^1.17
+    - if: matrix.provider == 'AWS'
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: us-west-1
+        role-to-assume: arn:aws:iam::342840881361:role/SandboxUser
     - run: go test ./task -v -timeout=30m -count=1
     - if: always()
       uses: actions/checkout@v2


### PR DESCRIPTION
Part of https://github.com/iterative/itops/issues/111, ready to merge after https://github.com/iterative/itops/pull/192. ⚠️ Don't remove the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets yet, because [`build-cml-ami.yml`](https://github.com/iterative/terraform-provider-iterative/blob/4fc3ee9192fa41a6ee57e9a54c00c79cbeba5c17/.github/workflows/build-cml-ami.yml) still relies on them. Partially closes https://github.com/iterative/itops/issues/111.