### PR TITLE
Add concurrency limit to smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,7 +61,7 @@ jobs:
     environment: automatic
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    concurrency: ${{ github.workflow }}-k8s
+    concurrency: ${{ github.workflow }}-K8S
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,4 @@
 name: Smoke Test
-concurrency: ${{ github.workflow }}
 permissions:
   id-token: write
 on:
@@ -7,6 +6,9 @@ on:
     paths: 'task/**'
   schedule:
   - cron: '0 9 * * 1'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   authorize:
     environment: ${{ (github.event_name == 'pull_request_target' &&
@@ -24,9 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         provider: [AWS, AZ, GCP]
-    concurrency: 
-      group: ${{ github.head_ref || github.ref }}-${{ matrix.provider }}
-      cancel-in-progress: true
+    concurrency: ${{ github.workflow }}-${{ matrix.provider }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -61,9 +61,7 @@ jobs:
     environment: automatic
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    concurrency: 
-      group: ${{ github.head_ref || github.ref }}-k8s
-      cancel-in-progress: true
+    concurrency: ${{ github.workflow }}-k8s
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,5 @@
 name: Smoke Test
+concurrency: ${{ github.workflow }}
 permissions:
   id-token: write
 on:
@@ -8,7 +9,9 @@ on:
   - cron: '0 9 * * 1'
 jobs:
   authorize:
-    environment: ${{ github.event_name == 'schedule' && 'automatic' || 'manual' }}
+    environment: ${{ (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository) &&
+      'manual' || 'automatic' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo ✓
@@ -21,6 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         provider: [AWS, AZ, GCP]
+    concurrency: 
+      group: ${{ github.head_ref || github.ref }}-${{ matrix.provider }}
+      cancel-in-progress: true
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -55,6 +61,9 @@ jobs:
     environment: automatic
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency: 
+      group: ${{ github.head_ref || github.ref }}-k8s
+      cancel-in-progress: true
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
This pull request enables automatic smoke tests on internal pull requests, and limits concurrency to 1.

* Pushing a new commit to a pull request when tests are running will cancel the current run and and start a new one.
* Pushing a new commit to a pull request when tests are running in another pull request will just queue the tests.