### PR TITLE
task: rename `workdir.input` => `storage.workdir` & make `output` a subpath

### DIFF
--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -113,7 +113,7 @@ func resourceTask() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"input": {
+						"workspace": {
 							Type:     schema.TypeString,
 							ForceNew: true,
 							Optional: true,
@@ -290,7 +290,7 @@ func resourceTaskBuild(ctx context.Context, d *schema.ResourceData, m interface{
 	directory_out := ""
 	if d.Get("storage").(*schema.Set).Len() > 0 {
 		storage := d.Get("storage").(*schema.Set).List()[0].(map[string]interface{})
-		directory = storage["input"].(string)
+		directory = storage["workspace"].(string)
 		directory_out = storage["output"].(string)
 	}
 

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -293,11 +291,7 @@ func resourceTaskBuild(ctx context.Context, d *schema.ResourceData, m interface{
 	if d.Get("storage").(*schema.Set).Len() > 0 {
 		storage := d.Get("storage").(*schema.Set).List()[0].(map[string]interface{})
 		directory = storage["input"].(string)
-
-		directory_out = filepath.Clean(storage["output"].(string))
-		if directory_out != "" && (filepath.IsAbs(directory_out) || strings.HasPrefix(directory_out, "../")) {
-			return nil, errors.New("storage output path should be relative to input path")
-		}
+		directory_out = storage["output"].(string)
 	}
 
 	t := common.Task{
@@ -346,18 +340,4 @@ func diagnostic(diags diag.Diagnostics, err error, severity diag.Severity) diag.
 		Severity: severity,
 		Summary:  err.Error(),
 	})
-}
-
-func isOutputValid(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return true
-	}
-	defer f.Close()
-
-	_, err = f.Readdir(1)
-	if err == io.EOF {
-		return true
-	}
-	return false
 }

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -113,7 +113,7 @@ func resourceTask() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"workspace": {
+						"workdir": {
 							Type:     schema.TypeString,
 							ForceNew: true,
 							Optional: true,
@@ -290,7 +290,7 @@ func resourceTaskBuild(ctx context.Context, d *schema.ResourceData, m interface{
 	directory_out := ""
 	if d.Get("storage").(*schema.Set).Len() > 0 {
 		storage := d.Get("storage").(*schema.Set).List()[0].(map[string]interface{})
-		directory = storage["workspace"].(string)
+		directory = storage["workdir"].(string)
 		directory_out = storage["output"].(string)
 	}
 

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -248,7 +248,7 @@ func (t *Task) Pull(ctx context.Context, destination, include string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, "/"+include)
+	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, include)
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
@@ -256,7 +256,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "/**")
+	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "**")
 }
 
 func (t *Task) Start(ctx context.Context) error {

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -198,7 +198,7 @@ func (t *Task) Delete(ctx context.Context) error {
 	logrus.Debug("Downloading Directory...")
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
-			if err := t.Pull(ctx, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
+			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err
 			}
 		}
@@ -243,12 +243,12 @@ func (t *Task) Logs(ctx context.Context) ([]string, error) {
 	return machine.Logs(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"])
 }
 
-func (t *Task) Pull(ctx context.Context, destination string) error {
+func (t *Task) Pull(ctx context.Context, destination, include string) error {
 	if err := t.Read(ctx); err != nil {
 		return err
 	}
 
-	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination)
+	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, "/"+include)
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
@@ -256,7 +256,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data")
+	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "/**")
 }
 
 func (t *Task) Start(ctx context.Context) error {

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -187,7 +187,7 @@ func (t *Task) Delete(ctx context.Context) error {
 	logrus.Debug("Downloading Directory...")
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
-			if err := t.Pull(ctx, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
+			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err
 			}
 		}
@@ -236,12 +236,12 @@ func (t *Task) Logs(ctx context.Context) ([]string, error) {
 	return machine.Logs(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"])
 }
 
-func (t *Task) Pull(ctx context.Context, destination string) error {
+func (t *Task) Pull(ctx context.Context, destination, include string) error {
 	if err := t.Read(ctx); err != nil {
 		return err
 	}
 
-	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination)
+	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, "/"+include)
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
@@ -249,7 +249,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data")
+	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "/**")
 }
 
 func (t *Task) Start(ctx context.Context) error {

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -241,7 +241,7 @@ func (t *Task) Pull(ctx context.Context, destination, include string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, "/"+include)
+	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, include)
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
@@ -249,7 +249,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "/**")
+	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "**")
 }
 
 func (t *Task) Start(ctx context.Context) error {

--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -94,7 +94,7 @@ func Status(ctx context.Context, remote string, initialStatus common.Status) (co
 func Transfer(ctx context.Context, source, destination string, include string) error {
 	include = filepath.Clean(include)
 	if filepath.IsAbs(include) || strings.HasPrefix(include, "../") {
-		return errors.New("storage.output path should be inside storage.workdir")
+		return errors.New("storage.output must be inside storage.workdir")
 	}
 
 	rules := []string{

--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	// "log"
 	"io"
 	"path/filepath"
 	"strings"
@@ -15,11 +16,21 @@ import (
 	_ "github.com/rclone/rclone/backend/s3"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/sync"
 
 	"terraform-provider-iterative/task/common"
 )
+
+// func init() {
+// 	operations.SyncPrintf = func(format string, a ...interface{}) {
+// 		log.Printf("[DEBUG] "+format, a...)
+// 	}
+// 	fs.LogPrint = func(level fs.LogLevel, text string) {
+// 		log.Println("[DEBUG]", level, text)
+// 	}
+// }
 
 type StatusReport struct {
 	Result string
@@ -90,7 +101,18 @@ func Status(ctx context.Context, remote string, initialStatus common.Status) (co
 	return initialStatus, nil
 }
 
-func Transfer(ctx context.Context, source, destination string) error {
+func Transfer(ctx context.Context, source, destination string, include string) error {
+	// ctx, ci := fs.AddConfig(ctx)
+	ctx, fi := filter.AddConfig(ctx)
+
+	// ci.LogLevel = fs.LogLevelDebug
+	// ci.StatsLogLevel = fs.LogLevelDebug
+	// ci.Progress = true
+
+	fi.AddRule("+ "+include)
+	fi.AddRule("+ "+include+"/**")
+	fi.AddRule("- **")
+
 	sourceFileSystem, err := fs.NewFs(ctx, source)
 	if err != nil {
 		return err

--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -94,7 +94,7 @@ func Status(ctx context.Context, remote string, initialStatus common.Status) (co
 func Transfer(ctx context.Context, source, destination string, include string) error {
 	include = filepath.Clean(include)
 	if filepath.IsAbs(include) || strings.HasPrefix(include, "../") {
-		return errors.New("storage output path should be relative to input path")
+		return errors.New("storage.output path should be inside storage.workdir")
 	}
 
 	rules := []string{

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -328,7 +328,7 @@ func (t *Task) Pull(ctx context.Context, destination, include string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, "/"+include)
+	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, include)
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
@@ -336,7 +336,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "/**")
+	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "**")
 }
 
 func (t *Task) Start(ctx context.Context) error {

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -266,7 +266,7 @@ func (t *Task) Delete(ctx context.Context) error {
 	logrus.Debug("Downloading Directory...")
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
-			if err := t.Pull(ctx, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
+			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err
 			}
 		}
@@ -323,12 +323,12 @@ func (t *Task) Logs(ctx context.Context) ([]string, error) {
 	return machine.Logs(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"])
 }
 
-func (t *Task) Pull(ctx context.Context, destination string) error {
+func (t *Task) Pull(ctx context.Context, destination, include string) error {
 	if err := t.Read(ctx); err != nil {
 		return err
 	}
 
-	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination)
+	return machine.Transfer(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", destination, "/"+include)
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
@@ -336,7 +336,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data")
+	return machine.Transfer(ctx, source, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]+"/data", "/**")
 }
 
 func (t *Task) Start(ctx context.Context) error {

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -242,7 +242,7 @@ func (t *Task) Pull(ctx context.Context, destination, include string) error {
 		return err
 	}
 
-	return machine.Transfer(ctx, dir, destination, "/"+include)
+	return machine.Transfer(ctx, dir, destination, include)
 }
 
 func (t *Task) Status(ctx context.Context) (common.Status, error) {

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -16,10 +16,8 @@ import (
 
 	_ "github.com/rclone/rclone/backend/local"
 
-	"github.com/rclone/rclone/fs"
-	"github.com/rclone/rclone/fs/sync"
-
 	"terraform-provider-iterative/task/common"
+	"terraform-provider-iterative/task/common/machine"
 	"terraform-provider-iterative/task/common/ssh"
 	"terraform-provider-iterative/task/k8s/client"
 	"terraform-provider-iterative/task/k8s/resources"
@@ -177,7 +175,7 @@ func (t *Task) Delete(ctx context.Context) error {
 			return err
 		}
 		log.Println("[INFO] Downloading Directory...")
-		if err := t.Pull(ctx, t.Attributes.DirectoryOut); err != nil {
+		if err := t.Pull(ctx, t.Attributes.Directory, t.Attributes.DirectoryOut); err != nil {
 			return err
 		}
 
@@ -221,7 +219,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 	return copyOptions.Run([]string{source, fmt.Sprintf("%s/%s:%s", t.Client.Namespace, pod, "/directory/directory")})
 }
 
-func (t *Task) Pull(ctx context.Context, destination string) error {
+func (t *Task) Pull(ctx context.Context, destination, include string) error {
 	waitSelector := fmt.Sprintf("controller-uid=%s", t.Resources.Job.Resource.GetObjectMeta().GetLabels()["controller-uid"])
 	pod, err := resources.WaitForPods(ctx, t.Client, 1*time.Second, t.Client.Cloud.Timeouts.Delete, t.Client.Namespace, waitSelector)
 	if err != nil {
@@ -244,21 +242,7 @@ func (t *Task) Pull(ctx context.Context, destination string) error {
 		return err
 	}
 
-	sourceFileSystem, err := fs.NewFs(ctx, dir)
-	if err != nil {
-		return err
-	}
-
-	destinationFileSystem, err := fs.NewFs(ctx, destination)
-	if err != nil {
-		return err
-	}
-
-	if err := sync.CopyDir(ctx, destinationFileSystem, sourceFileSystem, true); err != nil {
-		return err
-	}
-
-	return nil
+	return machine.Transfer(ctx, dir, destination, "/"+include)
 }
 
 func (t *Task) Status(ctx context.Context) (common.Status, error) {

--- a/task/task.go
+++ b/task/task.go
@@ -44,7 +44,7 @@ type Task interface {
 	Stop(ctx context.Context) error
 
 	Push(ctx context.Context, source string) error
-	Pull(ctx context.Context, destination string) error
+	Pull(ctx context.Context, destination, include string) error
 
 	Status(ctx context.Context) (common.Status, error)
 	Events(ctx context.Context) []common.Event


### PR DESCRIPTION
## Implementation of https://github.com/iterative/terraform-provider-iterative/issues/414#issuecomment-1061321093

### Breaking changes

* Rename `workdir` to `storage` (conceptually useful for [#299](https://github.com/iterative/terraform-provider-iterative/issues/299), but dispensable)
* Alter the behavior of `storage.output` as proposed in [#414 (comment)](https://github.com/iterative/terraform-provider-iterative/issues/414#issuecomment-1061321093)

### Tests

* Check that files not in `storage.output` aren't being downloaded
* Check that files in `storage.output` are being downloaded