### PR TITLE
Encrypt AWS images

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -1,7 +1,8 @@
 name: build-ami
 on: 
   push:
-    tags: ['ami*']
+    branches: [master]
+    paths: [environment]
 jobs:
   build-ami:
     runs-on: ubuntu-latest

--- a/environment/ami.pkr.hcl
+++ b/environment/ami.pkr.hcl
@@ -79,7 +79,7 @@ source "amazon-ebs" "source" {
   ami_name        = var.image_name
   ami_description = var.image_description
   ami_regions     = local.aws_release_regions
-  
+
   region        = var.aws_build_region
   instance_type = var.aws_build_instance
 
@@ -97,7 +97,7 @@ source "amazon-ebs" "source" {
   tags            = local.aws_tags
   run_tags        = local.aws_tags
   run_volume_tags = local.aws_tags
-  
+
   assume_role {
     role_arn     = var.aws_role_arn
     session_name = var.aws_role_session_name

--- a/environment/ami.pkr.hcl
+++ b/environment/ami.pkr.hcl
@@ -79,7 +79,7 @@ source "amazon-ebs" "source" {
   ami_name        = var.image_name
   ami_description = var.image_description
   ami_regions     = local.aws_release_regions
-
+  
   region        = var.aws_build_region
   instance_type = var.aws_build_instance
 
@@ -89,13 +89,15 @@ source "amazon-ebs" "source" {
   security_group_id = var.aws_security_group_id
   subnet_id         = var.aws_subnet_id
 
+  encrypt_boot = true
+
   force_delete_snapshot = true
   force_deregister      = true
 
   tags            = local.aws_tags
   run_tags        = local.aws_tags
   run_volume_tags = local.aws_tags
-
+  
   assume_role {
     role_arn     = var.aws_role_arn
     session_name = var.aws_role_session_name


### PR DESCRIPTION
Would fix https://github.com/iterative/viewer/issues/3193 CML–related errors. Still, encryption at rest is (technically) irrelevant for public images. 🙃 After migrating to NVIDIA NGC images (#384 & #410) this won't be needed anymore. 😅 