### PR TITLE
Remove dead code from cloud.go

### DIFF
--- a/task/common/cloud.go
+++ b/task/common/cloud.go
@@ -1,16 +1,8 @@
 package common
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
-	"regexp"
-	"strings"
 	"time"
-
-	"crypto/sha256"
-
-	"github.com/aohorodnyk/uid"
 )
 
 type Cloud struct {
@@ -45,31 +37,4 @@ func (c *Cloud) GetClosestRegion(regions map[string]Region) (string, error) {
 	}
 
 	return "", errors.New("native region not found")
-}
-
-// NormalizeIdentifier normalizes user-provided identifiers by adapting them to
-// the most strict cloud provider naming requisites.
-func NormalizeIdentifier(identifier string, long bool) string {
-	lowercase := strings.ToLower(identifier)
-	normalized := regexp.MustCompile("[^a-z0-9]+").ReplaceAllString(lowercase, "-")
-	normalized = regexp.MustCompile("(^-)|(-$)").ReplaceAllString(normalized, "")
-	if len(normalized) > 50 {
-		normalized = normalized[:50]
-	}
-	if long {
-		return fmt.Sprintf("tpi-%s-%s", normalized, generateSuffix(identifier, 8))
-	}
-	return generateSuffix(identifier, 8)
-}
-
-// generateSuffix deterministically generates a Base36 suffix of `size`
-// characters using `identifier` as the seed. This is useful to enhance
-// user-provided identifiers so they become valid "globally unique names" for
-// AWS S3, Google Storage and other services that require them.
-func generateSuffix(identifier string, size uint32) string {
-	digest := sha256.Sum256([]byte(identifier))
-	random := uid.NewRandCustom(bytes.NewReader(digest[:]))
-	encoder := uid.NewEncoderBase36()
-	provider := uid.NewProviderCustom(size, random, encoder)
-	return provider.MustGenerate().String()
 }


### PR DESCRIPTION
This code was moved to [`task/common/identifier.go`](https://github.com/iterative/terraform-provider-iterative/blob/master/task/common/identifier.go) long ago. 🤦🏼‍♂️ 