### PR TITLE
Avoid `rclone` error message on task logs

### DIFF
--- a/task/common/machine/script.go
+++ b/task/common/machine/script.go
@@ -61,7 +61,7 @@ sudo tee /etc/systemd/system/tpi-task.service > /dev/null <<END
 [Service]
   Type=simple
   ExecStart=/usr/bin/tpi-task
-  ExecStop=/bin/bash -c 'systemctl is-system-running | grep stopping || echo "{\\\\"result\\\\": \\\\"\$SERVICE_RESULT\\\\", \\\\"code\\\\": \\\\"\$EXIT_STATUS\\\\", \\\\"status\\\\": \\\\"\$EXIT_CODE\\\\"}" > "$TPI_LOG_DIRECTORY/status-$TPI_MACHINE_IDENTITY" && rclone copy "$TPI_LOG_DIRECTORY" "\$RCLONE_REMOTE/reports"'
+  ExecStop=/bin/bash -c 'systemctl is-system-running | grep stopping || echo "{\\\\"result\\\\": \\\\"\$SERVICE_RESULT\\\\", \\\\"code\\\\": \\\\"\$EXIT_STATUS\\\\", \\\\"status\\\\": \\\\"\$EXIT_CODE\\\\"}" > "$TPI_LOG_DIRECTORY/status-$TPI_MACHINE_IDENTITY" && RCLONE_CONFIG= rclone copy "$TPI_LOG_DIRECTORY" "\$RCLONE_REMOTE/reports"'
   ExecStopPost=/usr/bin/tpi-task-shutdown
   Environment=HOME=/root
   EnvironmentFile=/tmp/tpi-environment


### PR DESCRIPTION
Before, the `makeConfigPath` function returned [a default path](https://github.com/rclone/rclone/blob/7b7d780fffd8981e48c89096ef0e14400e625ca5/fs/config/config.go#L276), producing an [unhelpful warning message](https://github.com/rclone/rclone/blob/7b7d780fffd8981e48c89096ef0e14400e625ca5/fs/config/config.go#L359). Setting the `RCLONE_CONFIG` environment variable to to an empty string [causes](https://github.com/rclone/rclone/blob/7b7d780fffd8981e48c89096ef0e14400e625ca5/fs/config/config.go#L246) that function to return a bit [earlier](https://github.com/rclone/rclone/blob/7b7d780fffd8981e48c89096ef0e14400e625ca5/fs/config/config.go#L272), and causing [`configPath`](https://github.com/rclone/rclone/blob/7b7d780fffd8981e48c89096ef0e14400e625ca5/fs/config/config.go#L110) to be an empty string, replacing the warning with a silent debug [message](https://github.com/rclone/rclone/blob/7b7d780fffd8981e48c89096ef0e14400e625ca5/fs/config/config.go#L357).