### PR TITLE
Display real-time progress while transferring data

### DIFF
--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -132,7 +132,7 @@ func Transfer(ctx context.Context, source, destination string, include string) e
 		return err
 	}
 
-	defer progress(2*time.Second)()
+	defer progress(2 * time.Second)()
 
 	return sync.CopyDir(ctx, destinationFileSystem, sourceFileSystem, true)
 }
@@ -165,26 +165,26 @@ func Delete(ctx context.Context, destination string) error {
 }
 
 func progress(interval time.Duration) func() {
-		accounting.GlobalStats().ResetCounters()
-		ci := fs.GetConfig(context.Background())
-		ci.StatsOneLine = true
+	accounting.GlobalStats().ResetCounters()
+	ci := fs.GetConfig(context.Background())
+	ci.StatsOneLine = true
 
-		ticker := time.NewTicker(interval)
-		done := make(chan bool)
+	ticker := time.NewTicker(interval)
+	done := make(chan bool)
 
-		go func() {
-			for {
-				select {
-				case <-ticker.C:
-					logrus.Info(accounting.GlobalStats().String())
-				case <-done:
-					ticker.Stop()
-					return
-				}
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				logrus.Info(accounting.GlobalStats().String())
+			case <-done:
+				ticker.Stop()
+				return
 			}
-		}()
-
-		return func() {
-			done <- true
 		}
+	}()
+
+	return func() {
+		done <- true
+	}
 }

--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"time"
 
 	units "github.com/docker/go-units"
 
@@ -17,6 +18,7 @@ import (
 	_ "github.com/rclone/rclone/backend/s3"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/accounting"
 	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/sync"
@@ -130,6 +132,8 @@ func Transfer(ctx context.Context, source, destination string, include string) e
 		return err
 	}
 
+	defer progress(2*time.Second)()
+
 	return sync.CopyDir(ctx, destinationFileSystem, sourceFileSystem, true)
 }
 
@@ -158,4 +162,29 @@ func Delete(ctx context.Context, destination string) error {
 	}
 
 	return nil
+}
+
+func progress(interval time.Duration) func() {
+		accounting.GlobalStats().ResetCounters()
+		ci := fs.GetConfig(context.Background())
+		ci.StatsOneLine = true
+
+		ticker := time.NewTicker(interval)
+		done := make(chan bool)
+
+		go func() {
+			for {
+				select {
+				case <-ticker.C:
+					logrus.Info(accounting.GlobalStats().String())
+				case <-done:
+					ticker.Stop()
+					return
+				}
+			}
+		}()
+
+		return func() {
+			done <- true
+		}
 }


### PR DESCRIPTION
Follow–up of #463; reports progress every two[^1] seconds:

```
2022-03-30T20:46:36.483Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI Transferring 20kB (1000 files)...
iterative_task.example: Still destroying... [id=tpi-1o2y2wegfd8kq-3kmdmwbs-3dhqcjg6, 40s elapsed]
2022-03-30T20:46:38.483Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI         300 B / 400 B, 75%, 0 B/s, ETA - (xfr#15/24)
2022-03-30T20:46:40.484Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI     1.230 KiB / 1.934 KiB, 64%, 439 B/s, ETA 1s (xfr#63/103)
2022-03-30T20:46:42.483Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI     2.188 KiB / 3.477 KiB, 63%, 469 B/s, ETA 2s (xfr#112/182)
2022-03-30T20:46:44.483Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI     3.145 KiB / 5.098 KiB, 62%, 476 B/s, ETA 4s (xfr#161/265)
2022-03-30T20:46:46.483Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI     4.102 KiB / 6.777 KiB, 61%, 477 B/s, ETA 5s (xfr#210/351)
iterative_task.example: Still destroying... [id=tpi-1o2y2wegfd8kq-3kmdmwbs-3dhqcjg6, 50s elapsed]
...
2022-03-30T20:47:18.484Z [INFO]  provider.terraform-provider-iterative: [INFO] 🚀TPI    19.316 KiB / 19.453 KiB, 99%, 487 B/s, ETA 0s (xfr#989/1000)
2022-03-30T20:47:18.944Z [DEBUG] provider.terraform-provider-iterative: [DEBUG] 🚀TPI Emptying Bucket...
```

[^1]: @iterative/cml, feel free to propose a better interval 