### PR TITLE
Simplify bucket emptying mechanism

### DIFF
--- a/task/aws/resources/resource_bucket.go
+++ b/task/aws/resources/resource_bucket.go
@@ -78,52 +78,15 @@ func (b *Bucket) Update(ctx context.Context) error {
 }
 
 func (b *Bucket) Delete(ctx context.Context) error {
-	listInput := s3.ListObjectsV2Input{
+	input := s3.DeleteBucketInput{
 		Bucket: aws.String(b.Identifier),
 	}
-
-	for paginator := s3.NewListObjectsV2Paginator(b.Client.Services.S3, &listInput); paginator.HasMorePages(); {
-		page, err := paginator.NextPage(ctx)
-
-		if err != nil {
-			var e smithy.APIError
-			if errors.As(err, &e) && e.ErrorCode() == "NoSuchBucket" {
-				b.Resource = nil
-				return nil
-			}
+	
+	if _, err := b.Client.Services.S3.DeleteBucket(ctx, &input); err != nil {
+		var e smithy.APIError
+		if errors.As(err, &e) && e.ErrorCode() != "NoSuchBucket" {
 			return err
 		}
-
-		if len(page.Contents) == 0 {
-			break
-		}
-
-		var objects []types.ObjectIdentifier
-		for _, object := range page.Contents {
-			objects = append(objects, types.ObjectIdentifier{
-				Key: object.Key,
-			})
-		}
-
-		input := s3.DeleteObjectsInput{
-			Bucket: aws.String(b.Identifier),
-			Delete: &types.Delete{
-				Objects: objects,
-			},
-		}
-
-		if _, err = b.Client.Services.S3.DeleteObjects(ctx, &input); err != nil {
-			return err
-		}
-	}
-
-	deleteInput := s3.DeleteBucketInput{
-		Bucket: aws.String(b.Identifier),
-	}
-
-	_, err := b.Client.Services.S3.DeleteBucket(ctx, &deleteInput)
-	if err != nil {
-		return err
 	}
 
 	b.Resource = nil

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -196,7 +196,7 @@ func (t *Task) Read(ctx context.Context) error {
 
 func (t *Task) Delete(ctx context.Context) error {
 	logrus.Debug("Downloading Directory...")
-	if t.Read(ctx) == nil {
+	if t.Resources.Bucket.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
 			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -185,7 +185,7 @@ func (t *Task) Read(ctx context.Context) error {
 
 func (t *Task) Delete(ctx context.Context) error {
 	logrus.Debug("Downloading Directory...")
-	if t.Read(ctx) == nil {
+	if t.Resources.BlobContainer.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
 			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err

--- a/task/gcp/resources/resource_bucket.go
+++ b/task/gcp/resources/resource_bucket.go
@@ -61,25 +61,11 @@ func (b *Bucket) Update(ctx context.Context) error {
 }
 
 func (b *Bucket) Delete(ctx context.Context) error {
-	if b.Read(ctx) == common.NotFoundError {
-		return nil
-	}
-
-	deletePage := func(objects *storage.Objects) error {
-		for _, object := range objects.Items {
-			if err := b.Client.Services.Storage.Objects.Delete(b.Identifier, object.Name).Do(); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if err := b.Client.Services.Storage.Objects.List(b.Identifier).Pages(ctx, deletePage); err != nil {
-		return err
-	}
-
 	if err := b.Client.Services.Storage.Buckets.Delete(b.Identifier).Do(); err != nil {
-		return err
+		var e *googleapi.Error
+		if errors.As(err, &e) && e.Code != 404 {
+			return err
+		}
 	}
 
 	b.Resource = nil

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -264,7 +264,7 @@ func (t *Task) Read(ctx context.Context) error {
 
 func (t *Task) Delete(ctx context.Context) error {
 	logrus.Debug("Downloading Directory...")
-	if t.Read(ctx) == nil {
+	if t.Resources.Bucket.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
 			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err


### PR DESCRIPTION
### Follow-up of #420 and #453, closes #459

It turns out that #459 happened because when some resources are already missing, `t.Read()` fails and the emptying logic never runs.