### PR TITLE
Improve TF_LOG_PROVIDER logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/aohorodnyk/uid v1.1.0
 	github.com/aws/aws-sdk-go v1.40.27 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/aalpar/deheap v0.0.0-20200318053559-9a0c2883bd56 h1:hJO00l0f92EcQn8Yg
 github.com/aalpar/deheap v0.0.0-20200318053559-9a0c2883bd56/go.mod h1:EJFoWbcEEVK22GYKONJjtMNamGYe6p+3x1Pr6zV5gFs=
 github.com/abbot/go-http-auth v0.4.0 h1:QjmvZ5gSC7jm3Zg54DqWE/T5m1t2AfDu6QlXJT0EVT0=
 github.com/abbot/go-http-auth v0.4.0/go.mod h1:Cz6ARTIzApMJDzh5bRMSUou6UMSp0IEXg9km/ci7TJM=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=

--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -111,7 +111,7 @@ func hideUnwantedPrefix(levelText, newPrefix, message string) string {
 	var output string
 	for _, line := range strings.Split(message, "\n") {
 		formattedLine := fmt.Sprintf("[%s]\r%s %s", levelText, newPrefix, line)
-		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength - len(line)), 0)))
+		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength-len(stripansi.Strip(line))), 0)))
 		output += formattedLine + padding + "\n"
 	}
 

--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -88,10 +88,10 @@ func (f *tpiFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		for index, log := range logs {
 			prefix := fmt.Sprintf("\n\x1b[%dmLOG %d >> ", colors["foreground"], index)
 			message += strings.Trim(strings.ReplaceAll("\n"+strings.Trim(log.(string), "\n"), "\n", prefix), "\n")
-			if index + 1 < len(logs) {
+			if index+1 < len(logs) {
 				message += "\n"
 			}
-		} 
+		}
 	}
 
 	newPrefix := fmt.Sprintf("\x1b[%dmTPI [%s]\x1b[0m", levelColor, levelText)
@@ -106,13 +106,13 @@ func TpiLogger(d *schema.ResourceData) *logrus.Entry {
 
 func hideUnwantedPrefix(levelText, newPrefix, message string) string {
 	unwantedPrefixLength := len(fmt.Sprintf("yyyy-mm-ddThh:mm:ss.mmmZ [%s] provider.terraform-provider-iterative: [%[1]s]", levelText))
-	
+
 	var output string
 	for _, line := range strings.Split(message, "\n") {
 		formattedLine := fmt.Sprintf("[%s]\r%s %s", levelText, newPrefix, line)
-		padding := strings.Repeat(" ",  int(math.Max(float64(unwantedPrefixLength - len(line)), 0)))
+		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength-len(line)), 0)))
 		output += formattedLine + padding + "\n"
 	}
-	
+
 	return output
 }

--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -72,13 +72,13 @@ func (f *tpiFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 		message = fmt.Sprintf("\x1b[%dmStatus: queued 🔵\x1b[0m", colors["DEBUG"])
 
-		if status["succeeded"] != nil && status["succeeded"].(int) > 0 {
+		if status["succeeded"] != nil && status["succeeded"].(int) >= d.Get("parallelism").(int) {
 			message = fmt.Sprintf("\x1b[%dmStatus: completed succesfully 🟢\x1b[0m", colors["SUCCESS"])
 		}
 		if status["failed"] != nil && status["failed"].(int) > 0 {
 			message = fmt.Sprintf("\x1b[%dmStatus: completed with errors 🔴\x1b[0m", colors["ERROR"])
 		}
-		if status["running"] != nil && status["running"].(int) > 0 {
+		if status["running"] != nil && status["running"].(int) >= d.Get("parallelism").(int) {
 			message = fmt.Sprintf("\x1b[%dmStatus: running 🟡\x1b[0m", colors["WARNING"])
 		}
 	}

--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/acarl005/stripansi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/sirupsen/logrus"
 )
@@ -110,7 +111,7 @@ func hideUnwantedPrefix(levelText, newPrefix, message string) string {
 	var output string
 	for _, line := range strings.Split(message, "\n") {
 		formattedLine := fmt.Sprintf("[%s]\r%s %s", levelText, newPrefix, line)
-		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength-len(line)), 0)))
+		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength - len(line)), 0)))
 		output += formattedLine + padding + "\n"
 	}
 

--- a/iterative/utils/logger_test.go
+++ b/iterative/utils/logger_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestState(t *testing.T) {
 	d := generateSchemaData(t, map[string]interface{}{
-		"name": "mytask",
+		"name":        "mytask",
 		"parallelism": "1",
 		"status": map[string]interface{}{
 			"running": 0,
@@ -22,7 +22,7 @@ func TestState(t *testing.T) {
 
 func TestState2(t *testing.T) {
 	d := generateSchemaData(t, map[string]interface{}{
-		"name": "mytask",
+		"name":        "mytask",
 		"parallelism": "1",
 		"status": map[string]interface{}{
 			"running": 0,
@@ -36,7 +36,7 @@ func TestState2(t *testing.T) {
 
 func TestState3(t *testing.T) {
 	d := generateSchemaData(t, map[string]interface{}{
-		"name": "mytask",
+		"name":        "mytask",
 		"parallelism": "1",
 		"status": map[string]interface{}{
 			"running":   0,

--- a/iterative/utils/logger_test.go
+++ b/iterative/utils/logger_test.go
@@ -9,6 +9,7 @@ import (
 func TestState(t *testing.T) {
 	d := generateSchemaData(t, map[string]interface{}{
 		"name": "mytask",
+		"parallelism": "1",
 		"status": map[string]interface{}{
 			"running": 0,
 			"failed":  0,
@@ -22,6 +23,7 @@ func TestState(t *testing.T) {
 func TestState2(t *testing.T) {
 	d := generateSchemaData(t, map[string]interface{}{
 		"name": "mytask",
+		"parallelism": "1",
 		"status": map[string]interface{}{
 			"running": 0,
 			"failed":  1,
@@ -35,6 +37,7 @@ func TestState2(t *testing.T) {
 func TestState3(t *testing.T) {
 	d := generateSchemaData(t, map[string]interface{}{
 		"name": "mytask",
+		"parallelism": "1",
 		"status": map[string]interface{}{
 			"running":   0,
 			"succeeded": 1,
@@ -140,6 +143,12 @@ func generateSchemaData(t *testing.T, raw map[string]interface{}) *schema.Resour
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
+		},
+		"parallelism": {
+			Type:     schema.TypeInt,
+			ForceNew: true,
+			Optional: true,
+			Default:  1,
 		},
 		"script": {
 			Type:     schema.TypeString,

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -239,6 +239,8 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
+
+	t.Cached = false
 	return nil
 }
 

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -196,7 +196,7 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.AutoScalingGroup.Attributes.Addresses
 	t.Attributes.Status = t.Resources.AutoScalingGroup.Attributes.Status
 	t.Attributes.Events = t.Resources.AutoScalingGroup.Attributes.Events
-	
+
 	t.Cached = true
 	return nil
 }

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -90,7 +90,6 @@ type Task struct {
 		*resources.LaunchTemplate
 		*resources.AutoScalingGroup
 	}
-	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
@@ -148,10 +147,6 @@ func (t *Task) Create(ctx context.Context) error {
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	if t.Cached {
-		return nil
-	}
-
 	logrus.Info("Reading DefaultVPC...")
 	if err := t.DataSources.DefaultVPC.Read(ctx); err != nil {
 		return err
@@ -196,8 +191,6 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.AutoScalingGroup.Attributes.Addresses
 	t.Attributes.Status = t.Resources.AutoScalingGroup.Attributes.Status
 	t.Attributes.Events = t.Resources.AutoScalingGroup.Attributes.Events
-
-	t.Cached = true
 	return nil
 }
 
@@ -239,8 +232,6 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
-
-	t.Cached = false
 	return nil
 }
 

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -91,92 +91,99 @@ type Task struct {
 		*resources.SecurityGroup
 		*resources.VirtualMachineScaleSet
 	}
+	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
-	logrus.Debug("Creating ResourceGroup...")
+	logrus.Info("Creating ResourceGroup...")
 	if err := t.Resources.ResourceGroup.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating StorageAccount...")
+	logrus.Info("Creating StorageAccount...")
 	if err := t.Resources.StorageAccount.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating BlobContainer...")
+	logrus.Info("Creating BlobContainer...")
 	if err := t.Resources.BlobContainer.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating Credentials...")
+	logrus.Info("Creating Credentials...")
 	if err := t.DataSources.Credentials.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating VirtualNetwork...")
+	logrus.Info("Creating VirtualNetwork...")
 	if err := t.Resources.VirtualNetwork.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating SecurityGroup...")
+	logrus.Info("Creating SecurityGroup...")
 	if err := t.Resources.SecurityGroup.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating Subnet...")
+	logrus.Info("Creating Subnet...")
 	if err := t.Resources.Subnet.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating VirtualMachineScaleSet...")
+	logrus.Info("Creating VirtualMachineScaleSet...")
 	if err := t.Resources.VirtualMachineScaleSet.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Uploading Directory...")
+	logrus.Info("Uploading Directory...")
 	if t.Attributes.Environment.Directory != "" {
 		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
 			return err
 		}
 	}
-	logrus.Debug("Starting task...")
+	logrus.Info("Starting task...")
 	if err := t.Start(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Done!")
+	logrus.Info("Done!")
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
+	
+	t.Cached = true
 	return nil
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	logrus.Debug("Reading ResourceGroup...")
+	if t.Cached {
+		return nil
+	}
+
+	logrus.Info("Reading ResourceGroup...")
 	if err := t.Resources.ResourceGroup.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading StorageAccount...")
+	logrus.Info("Reading StorageAccount...")
 	if err := t.Resources.StorageAccount.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading BlobContainer...")
+	logrus.Info("Reading BlobContainer...")
 	if err := t.Resources.BlobContainer.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading Credentials...")
+	logrus.Info("Reading Credentials...")
 	if err := t.DataSources.Credentials.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading VirtualNetwork...")
+	logrus.Info("Reading VirtualNetwork...")
 	if err := t.Resources.VirtualNetwork.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading SecurityGroup...")
+	logrus.Info("Reading SecurityGroup...")
 	if err := t.Resources.SecurityGroup.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading Subnet...")
+	logrus.Info("Reading Subnet...")
 	if err := t.Resources.Subnet.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading VirtualMachineScaleSet...")
+	logrus.Info("Reading VirtualMachineScaleSet...")
 	if err := t.Resources.VirtualMachineScaleSet.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Done!")
+	logrus.Info("Done!")
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
@@ -184,47 +191,47 @@ func (t *Task) Read(ctx context.Context) error {
 }
 
 func (t *Task) Delete(ctx context.Context) error {
-	logrus.Debug("Downloading Directory...")
+	logrus.Info("Downloading Directory...")
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
 			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err
 			}
 		}
-		logrus.Debug("Emptying Bucket...")
+		logrus.Info("Emptying Bucket...")
 		if err := machine.Delete(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]); err != nil && err != common.NotFoundError {
 			return err
 		}
 	}
-	logrus.Debug("Deleting VirtualMachineScaleSet...")
+	logrus.Info("Deleting VirtualMachineScaleSet...")
 	if err := t.Resources.VirtualMachineScaleSet.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting Subnet...")
+	logrus.Info("Deleting Subnet...")
 	if err := t.Resources.Subnet.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting SecurityGroup...")
+	logrus.Info("Deleting SecurityGroup...")
 	if err := t.Resources.SecurityGroup.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting VirtualNetwork...")
+	logrus.Info("Deleting VirtualNetwork...")
 	if err := t.Resources.VirtualNetwork.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting BlobContainer...")
+	logrus.Info("Deleting BlobContainer...")
 	if err := t.Resources.BlobContainer.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting StorageAccount...")
+	logrus.Info("Deleting StorageAccount...")
 	if err := t.Resources.StorageAccount.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting ResourceGroup...")
+	logrus.Info("Deleting ResourceGroup...")
 	if err := t.Resources.ResourceGroup.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Done!")
+	logrus.Info("Done!")
 	return nil
 }
 

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -91,7 +91,6 @@ type Task struct {
 		*resources.SecurityGroup
 		*resources.VirtualMachineScaleSet
 	}
-	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
@@ -145,10 +144,6 @@ func (t *Task) Create(ctx context.Context) error {
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	if t.Cached {
-		return nil
-	}
-
 	logrus.Info("Reading ResourceGroup...")
 	if err := t.Resources.ResourceGroup.Read(ctx); err != nil {
 		return err
@@ -185,8 +180,6 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
-
-	t.Cached = true
 	return nil
 }
 
@@ -232,8 +225,6 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
-
-	t.Cached = false
 	return nil
 }
 

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -141,8 +141,6 @@ func (t *Task) Create(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
-
-	t.Cached = true
 	return nil
 }
 
@@ -187,6 +185,8 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
+	
+	t.Cached = true
 	return nil
 }
 
@@ -232,6 +232,8 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
+
+	t.Cached = false
 	return nil
 }
 

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -141,7 +141,7 @@ func (t *Task) Create(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
-	
+
 	t.Cached = true
 	return nil
 }

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -185,7 +185,7 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses
 	t.Attributes.Status = t.Resources.VirtualMachineScaleSet.Attributes.Status
 	t.Attributes.Events = t.Resources.VirtualMachineScaleSet.Attributes.Events
-	
+
 	t.Cached = true
 	return nil
 }

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -138,124 +138,133 @@ type Task struct {
 		*resources.InstanceTemplate
 		*resources.InstanceGroupManager
 	}
+	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
-	logrus.Debug("Creating DefaultNetwork...")
+	if t.Cached {
+		return nil
+	}
+
+	logrus.Info("Creating DefaultNetwork...")
 	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating Image...")
+	logrus.Info("Creating Image...")
 	if err := t.DataSources.Image.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating Bucket...")
+	logrus.Info("Creating Bucket...")
 	if err := t.Resources.Bucket.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating Credentials...")
+	logrus.Info("Creating Credentials...")
 	if err := t.DataSources.Credentials.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating FirewallInternalEgress...")
+	logrus.Info("Creating FirewallInternalEgress...")
 	if err := t.Resources.FirewallInternalEgress.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating FirewallInternalIngress...")
+	logrus.Info("Creating FirewallInternalIngress...")
 	if err := t.Resources.FirewallInternalIngress.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating FirewallExternalEgress...")
+	logrus.Info("Creating FirewallExternalEgress...")
 	if err := t.Resources.FirewallExternalEgress.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating FirewallExternalIngress...")
+	logrus.Info("Creating FirewallExternalIngress...")
 	if err := t.Resources.FirewallExternalIngress.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating FirewallDenyEgress...")
+	logrus.Info("Creating FirewallDenyEgress...")
 	if err := t.Resources.FirewallDenyEgress.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating FirewallDenyIngress...")
+	logrus.Info("Creating FirewallDenyIngress...")
 	if err := t.Resources.FirewallDenyIngress.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating InstanceTemplate...")
+	logrus.Info("Creating InstanceTemplate...")
 	if err := t.Resources.InstanceTemplate.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Creating InstanceGroupManager...")
+	logrus.Info("Creating InstanceGroupManager...")
 	if err := t.Resources.InstanceGroupManager.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Uploading Directory...")
+	logrus.Info("Uploading Directory...")
 	if t.Attributes.Environment.Directory != "" {
 		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
 			return err
 		}
 	}
-	logrus.Debug("Starting task...")
+	logrus.Info("Starting task...")
 	if err := t.Start(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Done!")
+	logrus.Info("Done!")
 	t.Attributes.Addresses = t.Resources.InstanceGroupManager.Attributes.Addresses
 	t.Attributes.Status = t.Resources.InstanceGroupManager.Attributes.Status
 	t.Attributes.Events = t.Resources.InstanceGroupManager.Attributes.Events
+	if t.Cached {
+		return nil
+	}
+	t.Cached = true
 	return nil
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	logrus.Debug("Reading DefaultNetwork...")
+	logrus.Info("Reading DefaultNetwork...")
 	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading Image...")
+	logrus.Info("Reading Image...")
 	if err := t.DataSources.Image.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading Bucket...")
+	logrus.Info("Reading Bucket...")
 	if err := t.Resources.Bucket.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading Credentials...")
+	logrus.Info("Reading Credentials...")
 	if err := t.DataSources.Credentials.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading FirewallInternalEgress...")
+	logrus.Info("Reading FirewallInternalEgress...")
 	if err := t.Resources.FirewallInternalEgress.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading FirewallInternalIngress...")
+	logrus.Info("Reading FirewallInternalIngress...")
 	if err := t.Resources.FirewallInternalIngress.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading FirewallExternalEgress...")
+	logrus.Info("Reading FirewallExternalEgress...")
 	if err := t.Resources.FirewallExternalEgress.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading FirewallExternalIngress...")
+	logrus.Info("Reading FirewallExternalIngress...")
 	if err := t.Resources.FirewallExternalIngress.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading FirewallDenyEgress...")
+	logrus.Info("Reading FirewallDenyEgress...")
 	if err := t.Resources.FirewallDenyEgress.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading FirewallDenyIngress...")
+	logrus.Info("Reading FirewallDenyIngress...")
 	if err := t.Resources.FirewallDenyIngress.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading InstanceTemplate...")
+	logrus.Info("Reading InstanceTemplate...")
 	if err := t.Resources.InstanceTemplate.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Reading InstanceGroupManager...")
+	logrus.Info("Reading InstanceGroupManager...")
 	if err := t.Resources.InstanceGroupManager.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Done!")
+	logrus.Info("Done!")
 	t.Attributes.Addresses = t.Resources.InstanceGroupManager.Attributes.Addresses
 	t.Attributes.Status = t.Resources.InstanceGroupManager.Attributes.Status
 	t.Attributes.Events = t.Resources.InstanceGroupManager.Attributes.Events
@@ -263,55 +272,55 @@ func (t *Task) Read(ctx context.Context) error {
 }
 
 func (t *Task) Delete(ctx context.Context) error {
-	logrus.Debug("Downloading Directory...")
+	logrus.Info("Downloading Directory...")
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
 			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
 				return err
 			}
 		}
-		logrus.Debug("Emptying Bucket...")
+		logrus.Info("Emptying Bucket...")
 		if err := machine.Delete(ctx, (*t.DataSources.Credentials.Resource)["RCLONE_REMOTE"]); err != nil && err != common.NotFoundError {
 			return err
 		}
 	}
-	logrus.Debug("Deleting InstanceGroupManager...")
+	logrus.Info("Deleting InstanceGroupManager...")
 	if err := t.Resources.InstanceGroupManager.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting InstanceTemplate...")
+	logrus.Info("Deleting InstanceTemplate...")
 	if err := t.Resources.InstanceTemplate.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting FirewallInternalEgress...")
+	logrus.Info("Deleting FirewallInternalEgress...")
 	if err := t.Resources.FirewallInternalEgress.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting FirewallInternalIngress...")
+	logrus.Info("Deleting FirewallInternalIngress...")
 	if err := t.Resources.FirewallInternalIngress.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting FirewallExternalEgress...")
+	logrus.Info("Deleting FirewallExternalEgress...")
 	if err := t.Resources.FirewallExternalEgress.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting FirewallExternalIngress...")
+	logrus.Info("Deleting FirewallExternalIngress...")
 	if err := t.Resources.FirewallExternalIngress.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting FirewallDenyEgress...")
+	logrus.Info("Deleting FirewallDenyEgress...")
 	if err := t.Resources.FirewallDenyEgress.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting FirewallDenyIngress...")
+	logrus.Info("Deleting FirewallDenyIngress...")
 	if err := t.Resources.FirewallDenyIngress.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Deleting Bucket...")
+	logrus.Info("Deleting Bucket...")
 	if err := t.Resources.Bucket.Delete(ctx); err != nil {
 		return err
 	}
-	logrus.Debug("Done!")
+	logrus.Info("Done!")
 	return nil
 }
 

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -138,7 +138,6 @@ type Task struct {
 		*resources.InstanceTemplate
 		*resources.InstanceGroupManager
 	}
-	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
@@ -208,10 +207,6 @@ func (t *Task) Create(ctx context.Context) error {
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	if t.Cached {
-		return nil
-	}
-
 	logrus.Info("Reading DefaultNetwork...")
 	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
 		return err
@@ -264,8 +259,6 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.InstanceGroupManager.Attributes.Addresses
 	t.Attributes.Status = t.Resources.InstanceGroupManager.Attributes.Status
 	t.Attributes.Events = t.Resources.InstanceGroupManager.Attributes.Events
-
-	t.Cached = true
 	return nil
 }
 
@@ -319,8 +312,6 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
-
-	t.Cached = false
 	return nil
 }
 

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -142,10 +142,6 @@ type Task struct {
 }
 
 func (t *Task) Create(ctx context.Context) error {
-	if t.Cached {
-		return nil
-	}
-
 	logrus.Info("Creating DefaultNetwork...")
 	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
 		return err
@@ -208,14 +204,14 @@ func (t *Task) Create(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.InstanceGroupManager.Attributes.Addresses
 	t.Attributes.Status = t.Resources.InstanceGroupManager.Attributes.Status
 	t.Attributes.Events = t.Resources.InstanceGroupManager.Attributes.Events
-	if t.Cached {
-		return nil
-	}
-	t.Cached = true
 	return nil
 }
 
 func (t *Task) Read(ctx context.Context) error {
+	if t.Cached {
+		return nil
+	}
+
 	logrus.Info("Reading DefaultNetwork...")
 	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
 		return err
@@ -268,6 +264,8 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Addresses = t.Resources.InstanceGroupManager.Attributes.Addresses
 	t.Attributes.Status = t.Resources.InstanceGroupManager.Attributes.Status
 	t.Attributes.Events = t.Resources.InstanceGroupManager.Attributes.Events
+
+	t.Cached = true
 	return nil
 }
 
@@ -321,6 +319,8 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
+
+	t.Cached = false
 	return nil
 }
 

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -209,7 +209,7 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
-	
+
 	t.Cached = false
 	return nil
 }

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -162,7 +162,7 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Task.Addresses = t.Resources.Job.Attributes.Addresses
 	t.Attributes.Task.Status = t.Resources.Job.Attributes.Status
 	t.Attributes.Task.Events = t.Resources.Job.Attributes.Events
-	
+
 	t.Cached = true
 	return nil
 }

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -93,7 +93,6 @@ type Task struct {
 		*resources.PersistentVolumeClaim
 		*resources.Job
 	}
-	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
@@ -142,10 +141,6 @@ func (t *Task) Create(ctx context.Context) error {
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	if t.Cached {
-		return nil
-	}
-
 	logrus.Info("Reading ConfigMap...")
 	if err := t.Resources.ConfigMap.Read(ctx); err != nil {
 		return err
@@ -162,8 +157,6 @@ func (t *Task) Read(ctx context.Context) error {
 	t.Attributes.Task.Addresses = t.Resources.Job.Attributes.Addresses
 	t.Attributes.Task.Status = t.Resources.Job.Attributes.Status
 	t.Attributes.Task.Events = t.Resources.Job.Attributes.Events
-
-	t.Cached = true
 	return nil
 }
 
@@ -209,8 +202,6 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
-
-	t.Cached = false
 	return nil
 }
 

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -209,6 +209,8 @@ func (t *Task) Delete(ctx context.Context) error {
 		return err
 	}
 	logrus.Info("Done!")
+	
+	t.Cached = false
 	return nil
 }
 

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"regexp"
@@ -15,6 +14,8 @@ import (
 	"k8s.io/kubectl/pkg/cmd/cp"
 
 	_ "github.com/rclone/rclone/backend/local"
+
+	"github.com/sirupsen/logrus"
 
 	"terraform-provider-iterative/task/common"
 	"terraform-provider-iterative/task/common/machine"
@@ -92,14 +93,15 @@ type Task struct {
 		*resources.PersistentVolumeClaim
 		*resources.Job
 	}
+	Cached bool
 }
 
 func (t *Task) Create(ctx context.Context) error {
-	log.Println("[INFO] Creating ConfigMap...")
+	logrus.Info("Creating ConfigMap...")
 	if err := t.Resources.ConfigMap.Create(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Creating PersistentVolumeClaim...")
+	logrus.Info("Creating PersistentVolumeClaim...")
 	if err := t.Resources.PersistentVolumeClaim.Create(ctx); err != nil {
 		return err
 	}
@@ -108,19 +110,19 @@ func (t *Task) Create(ctx context.Context) error {
 		os.Setenv("TPI_TRANSFER_MODE", "true")
 		defer os.Unsetenv("TPI_TRANSFER_MODE")
 
-		log.Println("[INFO] Deleting Job...")
+		logrus.Info("Deleting Job...")
 		if err := t.Resources.Job.Delete(ctx); err != nil {
 			return err
 		}
-		log.Println("[INFO] Creating ephemeral Job to upload directory...")
+		logrus.Info("Creating ephemeral Job to upload directory...")
 		if err := t.Resources.Job.Create(ctx); err != nil {
 			return err
 		}
-		log.Println("[INFO] Uploading Directory...")
+		logrus.Info("Uploading Directory...")
 		if err := t.Push(ctx, t.Attributes.Directory); err != nil {
 			return err
 		}
-		log.Println("[INFO] Deleting ephemeral Job to upload directory...")
+		logrus.Info("Deleting ephemeral Job to upload directory...")
 		if err := t.Resources.Job.Delete(ctx); err != nil {
 			return err
 		}
@@ -128,11 +130,11 @@ func (t *Task) Create(ctx context.Context) error {
 		os.Unsetenv("TPI_TRANSFER_MODE")
 	}
 
-	log.Println("[INFO] Creating Job...")
+	logrus.Info("Creating Job...")
 	if err := t.Resources.Job.Create(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Done!")
+	logrus.Info("Done!")
 	t.Attributes.Task.Addresses = t.Resources.Job.Attributes.Addresses
 	t.Attributes.Task.Status = t.Resources.Job.Attributes.Status
 	t.Attributes.Task.Events = t.Resources.Job.Attributes.Events
@@ -140,22 +142,28 @@ func (t *Task) Create(ctx context.Context) error {
 }
 
 func (t *Task) Read(ctx context.Context) error {
-	log.Println("[INFO] Reading ConfigMap...")
+	if t.Cached {
+		return nil
+	}
+
+	logrus.Info("Reading ConfigMap...")
 	if err := t.Resources.ConfigMap.Read(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Reading PersistentVolumeClaim...")
+	logrus.Info("Reading PersistentVolumeClaim...")
 	if err := t.Resources.PersistentVolumeClaim.Read(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Reading Job...")
+	logrus.Info("Reading Job...")
 	if err := t.Resources.Job.Read(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Done!")
+	logrus.Info("Done!")
 	t.Attributes.Task.Addresses = t.Resources.Job.Attributes.Addresses
 	t.Attributes.Task.Status = t.Resources.Job.Attributes.Status
 	t.Attributes.Task.Events = t.Resources.Job.Attributes.Events
+	
+	t.Cached = true
 	return nil
 }
 
@@ -166,20 +174,20 @@ func (t *Task) Delete(ctx context.Context) error {
 		defer os.Unsetenv("TPI_TRANSFER_MODE")
 		defer os.Unsetenv("TPI_PULL_MODE")
 
-		log.Println("[INFO] Deleting Job...")
+		logrus.Info("Deleting Job...")
 		if err := t.Resources.Job.Delete(ctx); err != nil {
 			return err
 		}
-		log.Println("[INFO] Creating ephemeral Job to retrieve directory...")
+		logrus.Info("Creating ephemeral Job to retrieve directory...")
 		if err := t.Resources.Job.Create(ctx); err != nil {
 			return err
 		}
-		log.Println("[INFO] Downloading Directory...")
+		logrus.Info("Downloading Directory...")
 		if err := t.Pull(ctx, t.Attributes.Directory, t.Attributes.DirectoryOut); err != nil {
 			return err
 		}
 
-		log.Println("[INFO] Deleting ephemeral Job to retrieve directory...")
+		logrus.Info("Deleting ephemeral Job to retrieve directory...")
 		if err := t.Resources.Job.Create(ctx); err != nil {
 			return err
 		}
@@ -188,19 +196,19 @@ func (t *Task) Delete(ctx context.Context) error {
 		os.Unsetenv("TPI_PULL_MODE")
 	}
 
-	log.Println("[INFO] Deleting Job...")
+	logrus.Info("Deleting Job...")
 	if err := t.Resources.Job.Delete(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Deleting PersistentVolumeClaim...")
+	logrus.Info("Deleting PersistentVolumeClaim...")
 	if err := t.Resources.PersistentVolumeClaim.Delete(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Deleting ConfigMap...")
+	logrus.Info("Deleting ConfigMap...")
 	if err := t.Resources.ConfigMap.Delete(ctx); err != nil {
 		return err
 	}
-	log.Println("[INFO] Done!")
+	logrus.Info("Done!")
 	return nil
 }
 


### PR DESCRIPTION
This pull request introduces some visual and conceptual improvements to the `TF_LOG_PROVIDER=INFO` internal logs. This approach is still fairly unideal beyond all remedy, but at least is easier on the eyes for ANSI terminal users; see https://github.com/iterative/terraform-provider-iterative/pull/423#pullrequestreview-901140497 for context.

#### Before
![Captura de pantalla 2022-03-31 a las 4 20 41](https://user-images.githubusercontent.com/11387611/160963297-4874a08e-bab9-4243-826b-6afdd3c873d0.png)
#### After
![Captura de pantalla 2022-03-31 a las 4 20 56](https://user-images.githubusercontent.com/11387611/160963318-67840594-a668-40c6-abc1-f584e83b4fa1.png)