### PR TITLE
Creation/deletion time warns

### DIFF
--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -18,6 +18,10 @@ import (
 	"terraform-provider-iterative/task/common"
 )
 
+var (
+	logTpl = "%s can take several minutes. If needed you might consider to increase %s timeout https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#timeout. Please wait..."
+)
+
 func resourceTask() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceTaskCreate,
@@ -160,10 +164,11 @@ func resourceTask() *schema.Resource {
 
 func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	logger := utils.TpiLogger(d)
-	if d.Get("spot").(float64) >= 0 {
-		logger.Info("Creation can take several minutes. With spot even longer, please consider to increase Create timeout. Please wait...")
-	} else {
-		logger.Info("Creation can take several minutes. Please wait...")
+	logger.Info(fmt.Sprintf(logTpl, "Creation", "Creation"))
+
+	spot := d.Get("spot").(float64)
+	if spot > 0 {
+		logger.Info("Fixed spot price does not ensure the Task to be launched. We recommend you to use auto spot price (0)")
 	}
 
 	task, err := resourceTaskBuild(ctx, d, m)
@@ -254,7 +259,7 @@ func resourceTaskRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 func resourceTaskDelete(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	logger := utils.TpiLogger(d)
-	logger.Info("Deletion can take several minutes. Please wait...")
+	logger.Info(fmt.Sprintf(logTpl, "Creation", "Creation"))
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -159,6 +159,13 @@ func resourceTask() *schema.Resource {
 }
 
 func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
+	logger := utils.TpiLogger(d)
+	if d.Get("spot").(float64) != nil {
+		logger.Info("Creation can take several minutes. With spot even longer, please consider to increase Create timeout. Please wait...")
+	} else {
+		logger.Info("Creation can take several minutes. Please wait...")
+	}
+
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {
 		return diagnostic(diags, err, diag.Error)
@@ -233,6 +240,7 @@ func resourceTaskRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	if err != nil {
 		return diagnostic(diags, err, diag.Warning)
 	}
+
 	d.Set("logs", logs)
 	d.SetId(task.GetIdentifier(ctx).Long())
 
@@ -245,6 +253,9 @@ func resourceTaskRead(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func resourceTaskDelete(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
+	logger := utils.TpiLogger(d)
+	logger.Info("Deletion can take several minutes. Please wait...")
+
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {
 		return diagnostic(diags, err, diag.Error)

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -160,7 +160,7 @@ func resourceTask() *schema.Resource {
 
 func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	logger := utils.TpiLogger(d)
-	if d.Get("spot").(float64) != nil {
+	if d.Get("spot").(float64) >= 0 {
 		logger.Info("Creation can take several minutes. With spot even longer, please consider to increase Create timeout. Please wait...")
 	} else {
 		logger.Info("Creation can take several minutes. Please wait...")

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -168,7 +168,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	spot := d.Get("spot").(float64)
 	if spot > 0 {
-		logger.Info("Fixed spot price does not ensure the Task to be launched. We recommend you to use auto spot price (0)")
+		logger.Info("Fixed spot price does not ensure the Task to be launched. It's recommended to use auto spot price (0)")
 	}
 
 	task, err := resourceTaskBuild(ctx, d, m)

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	logTpl = "%s can take several minutes. If needed you might consider to increase %s timeout https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#timeout. Please wait..."
+	logTpl = "%s may take several minutes (consider increasing `timeout` https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#timeout). Please wait."
 )
 
 func resourceTask() *schema.Resource {
@@ -164,7 +164,7 @@ func resourceTask() *schema.Resource {
 
 func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	logger := utils.TpiLogger(d)
-	logger.Info(fmt.Sprintf(logTpl, "Creation", "Creation"))
+	logger.Info(fmt.Sprintf(logTpl, "Creation"))
 
 	spot := d.Get("spot").(float64)
 	if spot > 0 {
@@ -259,7 +259,7 @@ func resourceTaskRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 func resourceTaskDelete(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	logger := utils.TpiLogger(d)
-	logger.Info(fmt.Sprintf(logTpl, "Deletion", "Deletion"))
+	logger.Info(fmt.Sprintf(logTpl, "Destruction"))
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -259,7 +259,7 @@ func resourceTaskRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 func resourceTaskDelete(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	logger := utils.TpiLogger(d)
-	logger.Info(fmt.Sprintf(logTpl, "Creation", "Creation"))
+	logger.Info(fmt.Sprintf(logTpl, "Deletion", "Deletion"))
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -168,7 +168,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	spot := d.Get("spot").(float64)
 	if spot > 0 {
-		logger.Info("Fixed spot price does not ensure the Task to be launched. It's recommended to use auto spot price (0)")
+		logger.Warn(fmt.Sprintf("Setting a maximum price `spot=%f` USD/h. Consider using auto-pricing (`spot=0`) instead.", spot))
 	}
 
 	task, err := resourceTaskBuild(ctx, d, m)


### PR DESCRIPTION
 - fixes a small part of #457 

```
 @DavidGOrtega UX: apply fails ungracefully when spot pricing is too low? (might be solved by TF_LOG_PROVIDER=INFO in this list below)
 @DavidGOrtega CLI UX/docs: clearly warn about how long it can take to provision (apply)
 @DavidGOrtega CLI UX/docs: clearly warn about how long it can take to clean up (destroy)
```

Im working to fix or improve the logic of listed below in another PRs

```
@DavidGOrtega UX: apply fails ungracefully when spot pricing is too low? (might be solved by TF_LOG_PROVIDER=INFO in this list below)
 
https://github.com/iterative/terraform-provider-iterative/issues/462
```