### PR TITLE
Fix `rclone` filters when `output` is `.`

### DIFF
--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -98,14 +98,13 @@ func Status(ctx context.Context, remote string, initialStatus common.Status) (co
 }
 
 func Transfer(ctx context.Context, source, destination string, include string) error {
-	include = filepath.Clean(include)
-	if filepath.IsAbs(include) || strings.HasPrefix(include, "../") {
+	if include = filepath.Clean(include); filepath.IsAbs(include) || strings.HasPrefix(include, "../") {
 		return errors.New("storage.output must be inside storage.workdir")
 	}
 
 	rules := []string{
-		"+ /" + include,
-		"+ /" + include + "/**",
+		"+ " + filepath.Clean("/" + include),
+		"+ " + filepath.Clean("/" + include + "/**"),
 		"- **",
 	}
 

--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -103,8 +103,8 @@ func Transfer(ctx context.Context, source, destination string, include string) e
 	}
 
 	rules := []string{
-		"+ " + filepath.Clean("/" + include),
-		"+ " + filepath.Clean("/" + include + "/**"),
+		"+ " + filepath.Clean("/"+include),
+		"+ " + filepath.Clean("/"+include+"/**"),
 		"- **",
 	}
 


### PR DESCRIPTION
Closes #482; it turns out that `+ /./**` doesn't work but `+ /**` does, and we have to call `filepath.Clean` one more time after converting paths to absolute.