### PR TITLE
Coerce Credentials to handle GCP OIDC

### DIFF
--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -328,14 +328,15 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		//	Common ProjectID ENVs:
 		//		https://github.com/google-github-actions/auth/blob/b05f71482f54380997bcc43a29ef5007de7789b1/src/main.ts#L187-L191
 		//		https://github.com/hashicorp/terraform-provider-google/blob/d6734812e2c6a679334dcb46932f4b92729fa98c/google/provider.go#L64-L73
-		env_project := utils.MultiEnvLoadFirst([]string{
-			"CLOUDSDK_CORE_PROJECT",
-			"CLOUDSDK_PROJECT",
-			"GCLOUD_PROJECT",
-			"GCP_PROJECT",
-			"GOOGLE_CLOUD_PROJECT",
-			"GOOGLE_PROJECT",
-		})
+		// env_project := utils.MultiEnvLoadFirst([]string{
+		// 	"CLOUDSDK_CORE_PROJECT",
+		// 	"CLOUDSDK_PROJECT",
+		// 	"GCLOUD_PROJECT",
+		// 	"GCP_PROJECT",
+		// 	"GOOGLE_CLOUD_PROJECT",
+		// 	"GOOGLE_PROJECT",
+		// })
+		env_project := ""
 		if env_project == "" {
 			// last effort to load
 			fromCredentialsID, err := utils.GCPCoerceOIDCCredentials(credentialsData)

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -346,7 +346,7 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		}
 		credentials.ProjectID = env_project
 	}
-	// re-visit below after test / credentials.JSON as a seperate field is not/? updated with project id found from env
+
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_DATA", string(credentials.JSON))
 	return credentials.ProjectID, service, nil
 }

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -328,15 +328,14 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		//	Common ProjectID ENVs:
 		//		https://github.com/google-github-actions/auth/blob/b05f71482f54380997bcc43a29ef5007de7789b1/src/main.ts#L187-L191
 		//		https://github.com/hashicorp/terraform-provider-google/blob/d6734812e2c6a679334dcb46932f4b92729fa98c/google/provider.go#L64-L73
-		// env_project := utils.MultiEnvLoadFirst([]string{
-		// 	"CLOUDSDK_CORE_PROJECT",
-		// 	"CLOUDSDK_PROJECT",
-		// 	"GCLOUD_PROJECT",
-		// 	"GCP_PROJECT",
-		// 	"GOOGLE_CLOUD_PROJECT",
-		// 	"GOOGLE_PROJECT",
-		// })
-		env_project := ""
+		env_project := utils.MultiEnvLoadFirst([]string{
+			"CLOUDSDK_CORE_PROJECT",
+			"CLOUDSDK_PROJECT",
+			"GCLOUD_PROJECT",
+			"GCP_PROJECT",
+			"GOOGLE_CLOUD_PROJECT",
+			"GOOGLE_PROJECT",
+		})
 		if env_project == "" {
 			// last effort to load
 			fromCredentialsID, err := utils.GCPCoerceOIDCCredentials(credentialsData)

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -307,8 +307,8 @@ func getServiceAccountData(saString string) (string, []string) {
 func getProjectService() (string, *gcp_compute.Service, error) {
 	var credentials *google.Credentials
 	var err error
-	credentialsData := []byte(utils.LoadGCPCredentials())
-	if len(credentialsData) > 0 {
+
+	if credentialsData := []byte(utils.LoadGCPCredentials()); len(credentialsData) > 0 {
 		credentials, err = google.CredentialsFromJSON(oauth2.NoContext, credentialsData, gcp_compute.ComputeScope)
 	} else {
 		credentials, err = google.FindDefaultCredentials(oauth2.NoContext, gcp_compute.ComputeScope)
@@ -338,7 +338,7 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		})
 		if coercedProjectID == "" {
 			// last effort to load
-			fromCredentialsID, err := utils.GCPCoerceOIDCCredentials(credentialsData)
+			fromCredentialsID, err := utils.GCPCoerceOIDCCredentials(credentials.JSON)
 			if err != nil {
 				return "", nil, fmt.Errorf("Couldn't extract the project identifier from the given credentials!: [%w]", err)
 			}

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -328,7 +328,7 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		//	Common ProjectID ENVs:
 		//		https://github.com/google-github-actions/auth/blob/b05f71482f54380997bcc43a29ef5007de7789b1/src/main.ts#L187-L191
 		//		https://github.com/hashicorp/terraform-provider-google/blob/d6734812e2c6a679334dcb46932f4b92729fa98c/google/provider.go#L64-L73
-		env_project := utils.MultiEnvLoadFirst([]string{
+		coercedProjectID := utils.MultiEnvLoadFirst([]string{
 			"CLOUDSDK_CORE_PROJECT",
 			"CLOUDSDK_PROJECT",
 			"GCLOUD_PROJECT",
@@ -336,15 +336,15 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 			"GOOGLE_CLOUD_PROJECT",
 			"GOOGLE_PROJECT",
 		})
-		if env_project == "" {
+		if coercedProjectID == "" {
 			// last effort to load
 			fromCredentialsID, err := utils.GCPCoerceOIDCCredentials(credentialsData)
 			if err != nil {
 				return "", nil, fmt.Errorf("Couldn't extract the project identifier from the given credentials!: [%w]", err)
 			}
-			env_project = fromCredentialsID
+			coercedProjectID = fromCredentialsID
 		}
-		credentials.ProjectID = env_project
+		credentials.ProjectID = coercedProjectID
 	}
 
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_DATA", string(credentials.JSON))

--- a/iterative/utils/helpers.go
+++ b/iterative/utils/helpers.go
@@ -89,6 +89,15 @@ func SetId(d *schema.ResourceData) {
 	}
 }
 
+func MultiEnvLoadFirst(envs []string) string {
+	for _, val := range envs {
+		if env_value := os.Getenv(val); env_value != "" {
+			return env_value
+		}
+	}
+	return ""
+}
+
 func LoadGCPCredentials() string {
 	credentialsData := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_DATA")
 	if len(credentialsData) == 0 {


### PR DESCRIPTION
After much experimentation and reading, I believe this to be the best option for supporting GCP's OIDC credentials.

I will caveat that we should include a docs warning that OIDC credentials from both AWS and GCP are only valid for an hour out of the box /CC myself https://github.com/iterative/cml.dev/pull/208