### PR TITLE
Fix `ubuntu-drivers autoinstall`

### DIFF
--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -22,7 +22,7 @@ if [ ! -f "$FILE" ]; then
   curl -sL https://deb.nodesource.com/setup_12.x | sudo bash
   sudo apt update && sudo apt-get install -y nodejs
 
-  sudo apt install -y ubuntu-drivers-common
+  sudo apt install -y ubuntu-drivers-common alsa-utils
   sudo ubuntu-drivers autoinstall
 
   sudo curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login


### PR DESCRIPTION
```console
$ sudo ubuntu-drivers autoinstall
ERROR:root:could not open aplay -l
Traceback (most recent call last):
  File "/usr/share/ubuntu-drivers-common/detect/sl-modem.py", line 35, in detect
    aplay = subprocess.Popen(
  File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'aplay'
No drivers found for installation.
$ sudo apt install --yes alsa-utils
···
$ sudo ubuntu-drivers autoinstall
No drivers found for installation.
```