### PR TITLE
Simplify Google Cloud credential detection

### DIFF
--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -16,6 +16,7 @@ import (
 
 	"gopkg.in/alessio/shellescape.v1"
 
+	"terraform-provider-iterative/iterative/gcp"
 	"terraform-provider-iterative/iterative/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -435,6 +436,11 @@ func provisionerCode(d *schema.ResourceData) (string, error) {
 		return code, err
 	}
 
+	var gcpCredentials string
+	if credentials, err := gcp.LoadGCPCredentials(); err == nil {
+		gcpCredentials = string(credentials.JSON)
+	}
+
 	data := make(map[string]interface{})
 	data["token"] = d.Get("token").(string)
 	data["repo"] = d.Get("repo").(string)
@@ -455,7 +461,7 @@ func provisionerCode(d *schema.ResourceData) (string, error) {
 	data["AZURE_CLIENT_SECRET"] = os.Getenv("AZURE_CLIENT_SECRET")
 	data["AZURE_SUBSCRIPTION_ID"] = os.Getenv("AZURE_SUBSCRIPTION_ID")
 	data["AZURE_TENANT_ID"] = os.Getenv("AZURE_TENANT_ID")
-	data["GOOGLE_APPLICATION_CREDENTIALS_DATA"] = utils.LoadGCPCredentials()
+	data["GOOGLE_APPLICATION_CREDENTIALS_DATA"] = gcpCredentials
 	data["KUBERNETES_CONFIGURATION"] = os.Getenv("KUBERNETES_CONFIGURATION")
 	data["container"] = isContainerAvailable(d.Get("cloud").(string))
 	data["setup"] = strings.Replace(string(setup[:]), "#/bin/sh", "", 1)

--- a/iterative/testdata/script_template_cloud_gcp.golden
+++ b/iterative/testdata/script_template_cloud_gcp.golden
@@ -40,7 +40,7 @@ fi
 sudo npm config set user 0 && sudo npm install --global 18 value with "quotes" and spaces
 sudo tee /usr/bin/cml.sh << 'EOF'
 #!/bin/sh
-export GOOGLE_APPLICATION_CREDENTIALS_DATA='7 value with "quotes" and spaces'
+export GOOGLE_APPLICATION_CREDENTIALS_DATA=''
 
 HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \

--- a/iterative/utils/helpers.go
+++ b/iterative/utils/helpers.go
@@ -123,18 +123,6 @@ func GCPCoerceOIDCCredentials(rawCreds []byte) (string, error) {
 	return projectID, nil
 }
 
-func LoadGCPCredentials() string {
-	credentialsData := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_DATA")
-	if len(credentialsData) == 0 {
-		credentialsPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-		if len(credentialsPath) > 0 {
-			jsonData, _ := os.ReadFile(credentialsPath)
-			credentialsData = string(jsonData)
-		}
-	}
-	return credentialsData
-}
-
 // Better way than copying?
 // https://github.com/hashicorp/terraform-provider-google/blob/8a362008bd4d36b6a882eb53455f87305e6dff52/google/service_scope.go#L5-L48
 func canonicalizeServiceScope(scope string) string {


### PR DESCRIPTION
There is no need of duplicating the behavior of the [`google.FindDefaultCredentials`](https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials) function.

The only custom credential source we introduce is `GOOGLE_APPLICATION_CREDENTIALS_DATA` and only because it's not supported yet:

* https://github.com/googleapis/google-api-go-client/issues/185