### PR TITLE
Fix TF_LOG `\r` hack for timezones other than UTC

### DIFF
--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -106,7 +106,8 @@ func TpiLogger(d *schema.ResourceData) *logrus.Entry {
 }
 
 func hideUnwantedPrefix(levelText, newPrefix, message string) string {
-	unwantedPrefixLength := len(fmt.Sprintf("yyyy-mm-ddThh:mm:ss.mmmZ [%s] provider.terraform-provider-iterative: [%[1]s]", levelText))
+	timeString := time.Now().Format("2006-01-02T15:04:05.000Z0700")
+	unwantedPrefixLength := len(fmt.Sprintf("%s [%s] provider.terraform-provider-iterative: [%[2]s]", timeString, levelText))
 
 	var output string
 	for _, line := range strings.Split(message, "\n") {


### PR DESCRIPTION
The length of the time string varies depending on the user timezone, and it breaks the count of padding spaces on timezones other than UTC. Time format copied from [hashicorp/go-hclog@b6b5567/intlogger.go:26](https://github.com/hashicorp/go-hclog/blob/b6b55671f4e5b82443139ee3e9f4417603c4cd72/intlogger.go#L26).


### Bug
#### Current Behavior
```console
TPI [INFO] LOG 0 >> Apr 16 16:36:01 ip-172-31-31-201 tpi-task[1930]: 56                 O]
TPI [INFO] Status: running •                                                          NFO]
```
#### Expected Behavior
```console
TPI [INFO] LOG 0 >> Apr 16 16:36:01 ip-172-31-31-201 tpi-task[1930]: 56                   
TPI [INFO] Status: running •                                                              
```
### Example

```go
package main

import (
	"fmt"
	"time"
)

func main() {
	t := time.Now().Format("2006-01-02T15:04:05.000Z0700")
	fmt.Printf("%s [%s] provider.terraform-provider-iterative: [%[2]s]\n", t, "INFO")
}
```

```console
$ TZ=UTC go run main.go
2022-04-16T20:56:36.715Z [INFO] provider.terraform-provider-iterative: [INFO]
$ TZ=America/Los_Angeles go run main.go
2022-04-16T13:56:05.440-0700 [INFO] provider.terraform-provider-iterative: [INFO]
```