### PR TITLE
Remove `journalctl` header and footer

### DIFF
--- a/task/common/machine/script.go
+++ b/task/common/machine/script.go
@@ -107,7 +107,7 @@ sudo systemctl enable tpi-task.service --now
 
 while sleep 5; do
   test -n "$TPI_MACHINE_LOGS" && journalctl > "$TPI_LOG_DIRECTORY/machine-$TPI_MACHINE_IDENTITY"
-  journalctl --no-hostname --output=short-iso --unit=tpi-task --utc | sed 's/^\([0-9-]*\)T\([0-9:]*\)+0000 \S*: \(.*\)/\1 \2 \3/g' > "$TPI_LOG_DIRECTORY/task-$TPI_MACHINE_IDENTITY"
+  journalctl --all --no-hostname --output=short-iso --quiet --unit=tpi-task --utc | sed 's/^\([0-9-]*\)T\([0-9:]*\)+0000 \S*: \(.*\)/\1 \2 \3/g' > "$TPI_LOG_DIRECTORY/task-$TPI_MACHINE_IDENTITY"
   NEW_TPI_LOG_DIRECTORY_HASH="$(md5sum "$TPI_LOG_DIRECTORY"/*)"
   if test "$NEW_TPI_LOG_DIRECTORY_HASH" != "$TPI_LOG_DIRECTORY_HASH"; then
     TPI_LOG_DIRECTORY_HASH="$NEW_TPI_LOG_DIRECTORY_HASH"


### PR DESCRIPTION
Redundant and not consistent across backends (see Kubernetes)
```
-- Logs begin at Sat 2022-04-16 16:34:38 UTC, end at Sat 2022-04-16 16:36:01 UTC
```