### PR TITLE
Add panic handling and background analytics

### DIFF
--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -173,7 +173,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {
-		utils.SendJitsuEvent(ctx, "task/apply", err, utils.ResourceData(d))
+		utils.SendJitsuEvent("task/apply", err, utils.ResourceData(d))
 		return diagnostic(diags, err, diag.Error)
 	}
 
@@ -188,7 +188,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 		}
 	}
 
-	utils.SendJitsuEvent(ctx, "task/apply", err, utils.ResourceData(d))
+	utils.SendJitsuEvent("task/apply", err, utils.ResourceData(d))
 	return
 }
 
@@ -265,16 +265,16 @@ func resourceTaskDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {
-		utils.SendJitsuEvent(ctx, "task/destroy", err, utils.ResourceData(d))
+		utils.SendJitsuEvent("task/destroy", err, utils.ResourceData(d))
 		return diagnostic(diags, err, diag.Error)
 	}
 
 	if err := task.Delete(ctx); err != nil {
-		utils.SendJitsuEvent(ctx, "task/destroy", err, utils.ResourceData(d))
+		utils.SendJitsuEvent("task/destroy", err, utils.ResourceData(d))
 		return diagnostic(diags, err, diag.Error)
 	}
 
-	utils.SendJitsuEvent(ctx, "task/destroy", err, utils.ResourceData(d))
+	utils.SendJitsuEvent("task/destroy", err, utils.ResourceData(d))
 	return
 }
 

--- a/iterative/resource_task.go
+++ b/iterative/resource_task.go
@@ -173,7 +173,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {
-		utils.SendJitsuEvent("task/apply", err, d)
+		utils.SendJitsuEvent(ctx, "task/apply", err, utils.ResourceData(d))
 		return diagnostic(diags, err, diag.Error)
 	}
 
@@ -188,7 +188,7 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, m interface
 		}
 	}
 
-	utils.SendJitsuEvent("task/apply", err, d)
+	utils.SendJitsuEvent(ctx, "task/apply", err, utils.ResourceData(d))
 	return
 }
 
@@ -265,16 +265,16 @@ func resourceTaskDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 	task, err := resourceTaskBuild(ctx, d, m)
 	if err != nil {
-		utils.SendJitsuEvent("task/destroy", err, d)
+		utils.SendJitsuEvent(ctx, "task/destroy", err, utils.ResourceData(d))
 		return diagnostic(diags, err, diag.Error)
 	}
 
 	if err := task.Delete(ctx); err != nil {
-		utils.SendJitsuEvent("task/destroy", err, d)
+		utils.SendJitsuEvent(ctx, "task/destroy", err, utils.ResourceData(d))
 		return diagnostic(diags, err, diag.Error)
 	}
 
-	utils.SendJitsuEvent("task/destroy", err, d)
+	utils.SendJitsuEvent(ctx, "task/destroy", err, utils.ResourceData(d))
 	return
 }
 

--- a/iterative/utils/analytics.go
+++ b/iterative/utils/analytics.go
@@ -212,7 +212,7 @@ func JitsuEventPayload(action string, e error, extra map[string]interface{}) map
 
 	err := ""
 	if e != nil {
-		err = reflect.TypeOf(e).Name()
+		err = reflect.TypeOf(e).String()
 	}
 
 	payload := map[string]interface{}{

--- a/iterative/utils/analytics.go
+++ b/iterative/utils/analytics.go
@@ -234,9 +234,9 @@ func JitsuEventPayload(action string, e error, extra map[string]interface{}) map
 }
 
 func SendJitsuEvent(action string, e error, extra map[string]interface{}) {
-	for _, prefix := range []string{"ITERATIVE", "DVC"} {
-		if _, ok := os.LookupEnv(prefix + "_NO_ANALYTICS"); ok {
-			logrus.Debugf("analytics: %s_NO_ANALYTICS environment variable is set", prefix)
+	for _, env := range []string{"DO_NOT_TRACK", "DVC_NO_ANALYTICS"} {
+		if _, ok := os.LookupEnv(env); ok {
+			logrus.Debugf("analytics: %s environment variable is set; doing nothing", env)
 			return
 		}
 	}

--- a/iterative/utils/analytics.go
+++ b/iterative/utils/analytics.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	Timeout  = 5 * time.Second
-	Endpoint = "https://telemetry.cml.dev?ip_policy=strict"
+	Endpoint = "https://telemetry.cml.dev/api/v1/s2s/event?ip_policy=strict"
 	Token    = "s2s.jtyjusrpsww4k9b76rrjri.bl62fbzrb7nd9n6vn5bpqt"
 )
 

--- a/iterative/utils/analytics.go
+++ b/iterative/utils/analytics.go
@@ -233,7 +233,7 @@ func JitsuEventPayload(action string, e error, extra map[string]interface{}) map
 	return payload
 }
 
-func SendJitsuEvent(ctx context.Context, action string, e error, extra map[string]interface{}) {
+func SendJitsuEvent(action string, e error, extra map[string]interface{}) {
 	for _, prefix := range []string{"ITERATIVE", "DVC"} {
 		if _, ok := os.LookupEnv(prefix + "_NO_ANALYTICS"); ok {
 			logrus.Debugf("analytics: %s_NO_ANALYTICS environment variable is set", prefix)
@@ -242,7 +242,7 @@ func SendJitsuEvent(ctx context.Context, action string, e error, extra map[strin
 	}
 
 	wg.Add(1)
-	ctx, _ = context.WithTimeout(ctx, Timeout)
+	ctx, _ := context.WithTimeout(context.Background(), Timeout)
 	go send(ctx, JitsuEventPayload(action, e, extra))
 }
 
@@ -280,7 +280,7 @@ func WaitForAnalyticsAndHandlePanics() {
 
 	if r != nil {
 		extra := map[string]interface{}{"stack": debug.Stack()}
-		SendJitsuEvent(context.Background(), "panic", fmt.Errorf("panic: %v", r), extra)
+		SendJitsuEvent("panic", fmt.Errorf("panic: %v", r), extra)
 	}
 
 	wg.Wait()

--- a/iterative/utils/analytics.go
+++ b/iterative/utils/analytics.go
@@ -3,9 +3,9 @@ package utils
 import (
 	"bytes"
 	"context"
-	"errors"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -13,9 +13,9 @@ import (
 	"os/exec"
 	"reflect"
 	"regexp"
-	"time"
-	"sync"
 	"runtime/debug"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,7 +34,7 @@ const (
 
 var (
 	Version string = "0.0.0"
-	wg sync.WaitGroup
+	wg      sync.WaitGroup
 )
 
 func getenv(key, defaultValue string) string {
@@ -235,7 +235,7 @@ func JitsuEventPayload(action string, e error, extra map[string]interface{}) map
 
 func SendJitsuEvent(ctx context.Context, action string, e error, extra map[string]interface{}) {
 	for _, prefix := range []string{"ITERATIVE", "DVC"} {
-		if _, ok := os.LookupEnv(prefix+"_NO_ANALYTICS"); ok {
+		if _, ok := os.LookupEnv(prefix + "_NO_ANALYTICS"); ok {
 			logrus.Debugf("analytics: %s_NO_ANALYTICS environment variable is set", prefix)
 			return
 		}

--- a/iterative/utils/analytics.go
+++ b/iterative/utils/analytics.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	Timeout  = 5 * time.Second
-	Endpoint = "https://telemetry.cml.dev"
+	Endpoint = "https://telemetry.cml.dev?ip_policy=strict"
 	Token    = "s2s.jtyjusrpsww4k9b76rrjri.bl62fbzrb7nd9n6vn5bpqt"
 )
 

--- a/main.go
+++ b/main.go
@@ -10,11 +10,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"terraform-provider-iterative/iterative"
+	"terraform-provider-iterative/iterative/utils"
 	"terraform-provider-iterative/task"
 	"terraform-provider-iterative/task/common"
 )
 
 func main() {
+	defer utils.WaitForAnalyticsAndHandlePanics()
+
 	if identifier := os.Getenv("TPI_TASK_IDENTIFIER"); identifier != "" {
 		provider := os.Getenv("TPI_TASK_CLOUD_PROVIDER")
 		region := os.Getenv("TPI_TASK_CLOUD_REGION")


### PR DESCRIPTION
Cascade on #493

* Sends `panic` contents and stack trace as part of analytics
* Runs analytics in the background and waits `Timeout` seconds for them to complete on exit
* Honors the analytics kill switches from the specification
* Renames some environment variables

~[Question: is `?ip_policy=strict` needed?](https://iterativeai.slack.com/archives/C0249LW0HAQ/p1650371913116649?thread_ts=1649179052.132839&cid=C0249LW0HAQ)~ Yes, see https://github.com/iterative/terraform-provider-iterative/pull/538/commits/dc3f90c1904d07851f775fcc74687b4e52690321

~We may want to use a clean context for analytics so it doesn't get cancellation signals from Terraform.~ Yes, see https://github.com/iterative/terraform-provider-iterative/pull/538/commits/f4d153d8cb635f1d44bdb64380f76e1aae6dad11