### PR TITLE
Proper GCP - OIDC termination

### DIFF
--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -27,8 +27,9 @@ if [ ! -f "$FILE" ]; then
   sudo apt install -y ubuntu-drivers-common
   sudo ubuntu-drivers autoinstall
 
-  sudo curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login
-  sudo chmod 755 /usr/bin/docker-credential-ecr-login
+  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
+  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
+  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
 
   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -279,11 +279,12 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	if err != nil {
 		return err
 	}
-	log.Fatalln(project)
+
 	instanceZone := getRegion(d.Get("region").(string))
 	instanceName := d.Get("name").(string)
 
-	service.Instances.Delete(project, instanceZone, instanceName).Do()
+	res, err := service.Instances.Delete(project, instanceZone, instanceName).Do()
+	os.WriteFile("/tmp/delete.txt", []byte(fmt.Sprintf("%s \n %v \n %w", project, res, err)), os.ModeAppend)
 	service.Firewalls.Delete(project, instanceName+"-ingress").Do()
 	service.Firewalls.Delete(project, instanceName+"-egress").Do()
 
@@ -318,6 +319,8 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 	if err != nil {
 		return "", nil, err
 	}
+
+	os.WriteFile("/tmp/auth.txt", json.Marshal(credentials.TokenSource.Token()), os.ModeAppend)
 
 	service, err := gcp_compute.New(oauth2.NewClient(oauth2.NoContext, credentials.TokenSource))
 	if err != nil {

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -319,10 +319,6 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	t, _ := credentials.TokenSource.Token()
-	j, _ := json.Marshal(t)
-	os.WriteFile("/tmp/auth.txt", j, os.ModeAppend)
-
 	service, err := gcp_compute.New(oauth2.NewClient(oauth2.NoContext, credentials.TokenSource))
 	if err != nil {
 		return "", nil, err
@@ -350,6 +346,17 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 			coercedProjectID = fromCredentialsID
 		}
 		credentials.ProjectID = coercedProjectID
+
+		// setup reuse of access_token
+		token, _ := credentials.TokenSource.Token()
+		//if err != nil {
+		//	return "", nil, err
+		//}
+		tokenJSON, _ := json.Marshal(token)
+		//if err != nil {
+		//	return "", nil, err
+		//}
+		os.Setenv("CML_GCP_ACCESS_TOKEN", string(tokenJSON))
 	}
 
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_DATA", string(credentials.JSON))

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -346,21 +346,22 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 			coercedProjectID = fromCredentialsID
 		}
 		credentials.ProjectID = coercedProjectID
-
-		// setup reuse of access_token
-		token, _ := credentials.TokenSource.Token()
-		//if err != nil {
-		//	return "", nil, err
-		//}
-		tokenJSON, _ := json.Marshal(token)
-		//if err != nil {
-		//	return "", nil, err
-		//}
-		os.Setenv("CML_GCP_ACCESS_TOKEN", string(tokenJSON))
 	}
 
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_DATA", string(credentials.JSON))
+	//os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_DATA", string(credentials.JSON))
 	return credentials.ProjectID, service, nil
+}
+
+func ExtractToken(credentials *google.Credentials) ([]byte, error) {
+	token, err := credentials.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return nil, err
+	}
+	return tokenJSON, nil
 }
 
 func coerceOIDCCredentials(credentialsJSON []byte) (string, error) {

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -283,8 +283,7 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	instanceZone := getRegion(d.Get("region").(string))
 	instanceName := d.Get("name").(string)
 
-	res, err := service.Instances.Delete(project, instanceZone, instanceName).Do()
-	os.WriteFile("/tmp/delete.txt", []byte(fmt.Sprintf("%s\n%v\n%s\n", project, res, err)), os.ModeAppend)
+	service.Instances.Delete(project, instanceZone, instanceName).Do()
 	service.Firewalls.Delete(project, instanceName+"-ingress").Do()
 	service.Firewalls.Delete(project, instanceName+"-egress").Do()
 

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -279,7 +279,7 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	if err != nil {
 		return err
 	}
-
+	log.Fatalln(project)
 	instanceZone := getRegion(d.Get("region").(string))
 	instanceName := d.Get("name").(string)
 

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -322,7 +322,6 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 	var tokenSource oauth2.TokenSource
 	if token, err := reuseToken(); err == nil && token != nil {
 		tokenSource = oauth2.ReuseTokenSource(token, credentials.TokenSource)
-		os.WriteFile("/tmp/reuse.txt", []byte("yes"), os.ModeAppend)
 	} else {
 		tokenSource = credentials.TokenSource
 	}
@@ -355,7 +354,6 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		credentials.ProjectID = coercedProjectID
 	}
 
-	//os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_DATA", string(credentials.JSON))
 	return credentials.ProjectID, service, nil
 }
 func reuseToken() (*oauth2.Token, error) {

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -320,7 +320,7 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 		return "", nil, err
 	}
 	var tokenSource oauth2.TokenSource
-	if token, err := reuseToken(); err != nil && token != nil {
+	if token, err := reuseToken(); err == nil && token != nil {
 		tokenSource = oauth2.ReuseTokenSource(token, credentials.TokenSource)
 		os.WriteFile("/tmp/reuse.txt", []byte("yes"), os.ModeAppend)
 	} else {

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -319,8 +319,9 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 	if err != nil {
 		return "", nil, err
 	}
-
-	os.WriteFile("/tmp/auth.txt", json.Marshal(credentials.TokenSource.Token()), os.ModeAppend)
+	t, _ := credentials.TokenSource.Token()
+	j, _ := json.Marshal(t)
+	os.WriteFile("/tmp/auth.txt", j, os.ModeAppend)
 
 	service, err := gcp_compute.New(oauth2.NewClient(oauth2.NoContext, credentials.TokenSource))
 	if err != nil {

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -284,7 +284,7 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	instanceName := d.Get("name").(string)
 
 	res, err := service.Instances.Delete(project, instanceZone, instanceName).Do()
-	os.WriteFile("/tmp/delete.txt", []byte(fmt.Sprintf("%s \n %v \n %w", project, res, err)), os.ModeAppend)
+	os.WriteFile("/tmp/delete.txt", []byte(fmt.Sprintf("%s\n%v\n%s\n", project, res, err)), os.ModeAppend)
 	service.Firewalls.Delete(project, instanceName+"-ingress").Do()
 	service.Firewalls.Delete(project, instanceName+"-egress").Do()
 
@@ -322,6 +322,7 @@ func getProjectService() (string, *gcp_compute.Service, error) {
 	var tokenSource oauth2.TokenSource
 	if token, err := reuseToken(); err != nil && token != nil {
 		tokenSource = oauth2.ReuseTokenSource(token, credentials.TokenSource)
+		os.WriteFile("/tmp/reuse.txt", []byte("yes"), os.ModeAppend)
 	} else {
 		tokenSource = credentials.TokenSource
 	}

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -437,6 +437,7 @@ func provisionerCode(d *schema.ResourceData) (string, error) {
 	var gcpToken []byte
 	if credentials, err := gcp.LoadGCPCredentials(); err == nil {
 		gcpCredentials = string(credentials.JSON)
+		// reuse token for oidc
 		if credentials.ProjectID == "" {
 			gcpToken, _ = gcp.ExtractToken(credentials)
 		}

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -333,6 +333,7 @@ export AZURE_TENANT_ID={{escape .AZURE_TENANT_ID}}
 {{- end}}
 {{- if eq .cloud "gcp"}}
 export GOOGLE_APPLICATION_CREDENTIALS_DATA={{escape .GOOGLE_APPLICATION_CREDENTIALS_DATA}}
+export CML_GCP_ACCESS_TOKEN={{escape .CML_GCP_ACCESS_TOKEN}}
 {{- end}}
 {{- if eq .cloud "kubernetes"}}
 export KUBERNETES_CONFIGURATION={{escape .KUBERNETES_CONFIGURATION}}
@@ -458,6 +459,7 @@ func provisionerCode(d *schema.ResourceData) (string, error) {
 	data["AZURE_SUBSCRIPTION_ID"] = os.Getenv("AZURE_SUBSCRIPTION_ID")
 	data["AZURE_TENANT_ID"] = os.Getenv("AZURE_TENANT_ID")
 	data["GOOGLE_APPLICATION_CREDENTIALS_DATA"] = gcpCredentials
+	data["CML_GCP_ACCESS_TOKEN"] = os.Getenv("CML_GCP_ACCESS_TOKEN")
 	data["KUBERNETES_CONFIGURATION"] = os.Getenv("KUBERNETES_CONFIGURATION")
 	data["container"] = isContainerAvailable(d.Get("cloud").(string))
 	data["setup"] = strings.Replace(environment.SetupScript, "#/bin/sh", "", 1)

--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -14,7 +14,6 @@ import (
 	"text/template"
 	"time"
 
-	"golang.org/x/oauth2/google"
 	"gopkg.in/alessio/shellescape.v1"
 
 	"terraform-provider-iterative/environment"
@@ -435,13 +434,12 @@ func provisionerCode(d *schema.ResourceData) (string, error) {
 	}
 
 	var gcpCredentials string
-	var credentials *google.Credentials
+	var gcpToken []byte
 	if credentials, err := gcp.LoadGCPCredentials(); err == nil {
 		gcpCredentials = string(credentials.JSON)
-	}
-	var gcpToken []byte
-	if credentials.ProjectID == "" {
-		gcpToken, _ = gcp.ExtractToken(credentials)
+		if credentials.ProjectID == "" {
+			gcpToken, _ = gcp.ExtractToken(credentials)
+		}
 	}
 
 	data := make(map[string]interface{})

--- a/iterative/testdata/script_template_cloud_aws.golden
+++ b/iterative/testdata/script_template_cloud_aws.golden
@@ -28,8 +28,9 @@ if [ ! -f "$FILE" ]; then
   sudo apt install -y ubuntu-drivers-common
   sudo ubuntu-drivers autoinstall
 
-  sudo curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login
-  sudo chmod 755 /usr/bin/docker-credential-ecr-login
+  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
+  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
+  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
 
   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list

--- a/iterative/testdata/script_template_cloud_azure.golden
+++ b/iterative/testdata/script_template_cloud_azure.golden
@@ -28,8 +28,9 @@ if [ ! -f "$FILE" ]; then
   sudo apt install -y ubuntu-drivers-common
   sudo ubuntu-drivers autoinstall
 
-  sudo curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login
-  sudo chmod 755 /usr/bin/docker-credential-ecr-login
+  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
+  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
+  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
 
   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list

--- a/iterative/testdata/script_template_cloud_gcp.golden
+++ b/iterative/testdata/script_template_cloud_gcp.golden
@@ -28,8 +28,9 @@ if [ ! -f "$FILE" ]; then
   sudo apt install -y ubuntu-drivers-common
   sudo ubuntu-drivers autoinstall
 
-  sudo curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login
-  sudo chmod 755 /usr/bin/docker-credential-ecr-login
+  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
+  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
+  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
 
   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
@@ -43,6 +44,7 @@ sudo npm config set user 0 && sudo npm install --global 18 value with "quotes" a
 sudo tee /usr/bin/cml.sh << 'EOF'
 #!/bin/sh
 export GOOGLE_APPLICATION_CREDENTIALS_DATA=''
+export CML_GCP_ACCESS_TOKEN=''
 
 HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \

--- a/iterative/testdata/script_template_cloud_invalid.golden
+++ b/iterative/testdata/script_template_cloud_invalid.golden
@@ -28,8 +28,9 @@ if [ ! -f "$FILE" ]; then
   sudo apt install -y ubuntu-drivers-common
   sudo ubuntu-drivers autoinstall
 
-  sudo curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login
-  sudo chmod 755 /usr/bin/docker-credential-ecr-login
+  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
+  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
+  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
 
   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list


### PR DESCRIPTION
You can only generate one access token per oidc authorization, so if oidc creds are used we need to pass the access_token to the instance to properly self-terminate.

Closes: https://github.com/iterative/cml/issues/989