### PR TITLE
Fix data synchronization logs

### DIFF
--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -100,9 +100,9 @@ func (f *tpiFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func TpiLogger(d *schema.ResourceData) *logrus.Entry {
-	logrus.SetFormatter(&tpiFormatter{})
-
-	return logrus.WithFields(logrus.Fields{"d": d})
+	logger := logrus.New()
+	logger.SetFormatter(&tpiFormatter{})
+	return logger.WithFields(logrus.Fields{"d": d})
 }
 
 func hideUnwantedPrefix(levelText, newPrefix, message string) string {

--- a/task/common/machine/storage.go
+++ b/task/common/machine/storage.go
@@ -34,6 +34,15 @@ type StatusReport struct {
 	Code   string
 }
 
+func init() {
+	operations.SyncPrintf = func(format string, a ...interface{}) {
+		logrus.Debugf(format, a...)
+	}
+	fs.LogPrint = func(level fs.LogLevel, text string) {
+		logrus.Debug(text)
+	}
+}
+
 func Reports(ctx context.Context, remote, prefix string) ([]string, error) {
 	remoteFileSystem, err := fs.NewFs(ctx, remote)
 	if err != nil {


### PR DESCRIPTION
Closes #566 and redirects `rclone` notices to the `[DEBUG]` level.