### PR TITLE
`runner` tempdir patch

### DIFF
--- a/iterative/resource_runner.go
+++ b/iterative/resource_runner.go
@@ -344,7 +344,7 @@ export KUBERNETES_CONFIGURATION={{escape .KUBERNETES_CONFIGURATION}}
 {{.runner_startup_script}}
 {{- end}}
 
-HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
+HOME="$(mktemp -d -p /opt)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
   {{if .name}} --name {{escape .name}}{{end}} \
   {{if .labels}} --labels {{escape .labels}}{{end}} \
   {{if .idle_timeout}} --idle-timeout {{escape .idle_timeout}}{{end}} \

--- a/iterative/testdata/script_template_cloud_aws.golden
+++ b/iterative/testdata/script_template_cloud_aws.golden
@@ -47,7 +47,7 @@ export AWS_SECRET_ACCESS_KEY='0 value with "quotes" and spaces'
 export AWS_ACCESS_KEY_ID='1 value with "quotes" and spaces'
 export AWS_SESSION_TOKEN='2 value with "quotes" and spaces'
 
-HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
+HOME="$(mktemp -d -p /opt)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \
    --labels '16 value with "quotes" and spaces' \
    --idle-timeout 11 \

--- a/iterative/testdata/script_template_cloud_azure.golden
+++ b/iterative/testdata/script_template_cloud_azure.golden
@@ -48,7 +48,7 @@ export AZURE_CLIENT_SECRET='4 value with "quotes" and spaces'
 export AZURE_SUBSCRIPTION_ID='5 value with "quotes" and spaces'
 export AZURE_TENANT_ID='6 value with "quotes" and spaces'
 
-HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
+HOME="$(mktemp -d -p /opt)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \
    --labels '16 value with "quotes" and spaces' \
    --idle-timeout 11 \

--- a/iterative/testdata/script_template_cloud_gcp.golden
+++ b/iterative/testdata/script_template_cloud_gcp.golden
@@ -46,7 +46,7 @@ sudo tee /usr/bin/cml.sh << 'EOF'
 export GOOGLE_APPLICATION_CREDENTIALS_DATA=''
 export CML_GCP_ACCESS_TOKEN=''
 
-HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
+HOME="$(mktemp -d -p /opt)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \
    --labels '16 value with "quotes" and spaces' \
    --idle-timeout 11 \

--- a/iterative/testdata/script_template_cloud_invalid.golden
+++ b/iterative/testdata/script_template_cloud_invalid.golden
@@ -44,7 +44,7 @@ sudo npm config set user 0 && sudo npm install --global 18 value with "quotes" a
 sudo tee /usr/bin/cml.sh << 'EOF'
 #!/bin/sh
 
-HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
+HOME="$(mktemp -d -p /opt)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \
    --labels '16 value with "quotes" and spaces' \
    --idle-timeout 11 \

--- a/iterative/testdata/script_template_cloud_kubernetes.golden
+++ b/iterative/testdata/script_template_cloud_kubernetes.golden
@@ -2,7 +2,7 @@
 sudo systemctl is-enabled cml.service && return 0
 export KUBERNETES_CONFIGURATION='8 value with "quotes" and spaces'
 
-HOME="$(mktemp -d)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
+HOME="$(mktemp -d -p /opt)" exec $(which cml-runner || echo $(which cml-internal || echo cml) runner) \
    --name '10 value with "quotes" and spaces' \
    --labels '16 value with "quotes" and spaces' \
    --idle-timeout 11 \


### PR DESCRIPTION
 - partially fixes: https://github.com/iterative/cml/issues/1006
 - semi-related: https://github.com/iterative/terraform-provider-iterative/issues/581
 
I think the real fix is probably to run the GHA client in a separate `slice` enforcing resource limits