### PR TITLE
Fix stray brackets on status messages

### DIFF
--- a/iterative/utils/logger.go
+++ b/iterative/utils/logger.go
@@ -53,7 +53,7 @@ func hideUnwantedPrefix(levelText, newPrefix, message string) string {
 	var output string
 	for _, line := range strings.Split(message, "\n") {
 		formattedLine := fmt.Sprintf("[%s]\r%s %s", levelText, newPrefix, line)
-		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength-len(stripansi.Strip(line))), 0)))
+		padding := strings.Repeat(" ", int(math.Max(float64(unwantedPrefixLength-len([]rune(stripansi.Strip(line)))), 0)))
 		output += formattedLine + padding + "\n"
 	}
 


### PR DESCRIPTION
### Before
```
TPI [INFO] Status: completed successfully •                                           ]
```

### After
```
TPI [INFO] Status: completed successfully •                                           
```