### PR TITLE
Avoid pinning `aws` GPU images to a specific date

### DIFF
--- a/task/aws/resources/data_source_image.go
+++ b/task/aws/resources/data_source_image.go
@@ -34,7 +34,7 @@ func (i *Image) Read(ctx context.Context) error {
 	image := i.Identifier
 	images := map[string]string{
 		"ubuntu": "ubuntu@099720109477:x86_64:*ubuntu/images/hvm-ssd/ubuntu-focal-20.04*",
-		"nvidia": "ubuntu@898082745236:x86_64:Deep Learning AMI GPU CUDA 11.3.1 (Ubuntu 20.04) 20220303",
+		"nvidia": "ubuntu@898082745236:x86_64:Deep Learning AMI GPU CUDA 11.3.1 (Ubuntu 20.04) *",
 	}
 	if val, ok := images[image]; ok {
 		image = val

--- a/task/aws/resources/data_source_image.go
+++ b/task/aws/resources/data_source_image.go
@@ -34,7 +34,7 @@ func (i *Image) Read(ctx context.Context) error {
 	image := i.Identifier
 	images := map[string]string{
 		"ubuntu": "ubuntu@099720109477:x86_64:*ubuntu/images/hvm-ssd/ubuntu-focal-20.04*",
-		"nvidia": "ubuntu@898082745236:x86_64:Deep Learning AMI GPU CUDA 11.3.1 (Ubuntu 20.04) *",
+		"nvidia": "ubuntu@898082745236:x86_64:Deep Learning AMI GPU CUDA 11.3.* (Ubuntu 20.04) *",
 	}
 	if val, ok := images[image]; ok {
 		image = val


### PR DESCRIPTION
Apparently, they disappear when a new image is published