### PR TITLE
Runner Fix nvidia setup and restart

### DIFF
--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -17,6 +17,10 @@ if [ ! -f "$FILE" ]; then
   sudo usermod -aG docker ubuntu
   sudo setfacl --modify user:ubuntu:rw /var/run/docker.sock
 
+  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
+  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
+  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
+
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
   sudo apt update && sudo apt-get install -y terraform
@@ -25,16 +29,14 @@ if [ ! -f "$FILE" ]; then
   sudo apt update && sudo apt-get install -y nodejs
 
   sudo apt install -y ubuntu-drivers-common
-  sudo ubuntu-drivers autoinstall
-
-  get_ecr_helper="curl https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login --output /usr/bin/docker-credential-ecr-login"
-  chmod_ecr_help="chmod 755 /usr/bin/docker-credential-ecr-login"
-  sudo systemd-run --same-dir --no-block --service-type=exec bash -c "$get_ecr_help && $chmod_ecr_help"
-
-  curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-  curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-  sudo apt update && sudo apt install -y nvidia-docker2
-  sudo systemctl restart docker
-
+  if ubuntu-drivers devices | grep 'NVIDIA' > /dev/null; then 
+    sudo ubuntu-drivers install
+    
+    curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+    curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+    sudo apt update && sudo apt install -y nvidia-docker2
+    sudo systemctl restart docker
+  fi
+  
   echo OK | sudo tee "$FILE"
 fi


### PR DESCRIPTION
This has been a tricky PR. After fixing the restart to be able to access the GPU due to kernel upgrade we were hitting a very funny error seen [here](https://github.com/golang/go/issues/21941) and [here](https://github.com/golang/go/issues/15113) hanging the ssh connection on DIAL and never escaping back.
To solve it I had to put the logs function within a timed-out function.

This PR:
 - closes #606
 - closes https://github.com/iterative/cml/issues/1065#issuecomment-1157607462
 - Removes dependency of specifying the GPU to setup the NVIDIA. Uses ubuntu-drivers for auto detection
 - Makes non GPU instances setup much faster avoiding to install NVIDIA and nvidia-docker