### PR TITLE
Lint only on pull request events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
   - cron: '0 9 * * 1'  # M H d m w (Mondays at 9:00)
 jobs:
   lint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
> [_Not fetching patch for showing only new issues because it's not a pull request context: event name is push_ (7149297668)](https://github.com/iterative/terraform-provider-iterative/runs/7149297668?check_suite_focus=true#step:3:13)

After #616[^1] all the lint checks on the main branch are red otherwise; this pull request disables lint on the main branch.


[^1]: Of course: https://en.wikipedia.org/wiki/Number_of_the_beast