### PR TITLE
`task` Fix id-generation

### DIFF
--- a/task/common/identifier.go
+++ b/task/common/identifier.go
@@ -41,7 +41,7 @@ func NewRandomIdentifier() Identifier {
 
 func (i Identifier) Long() string {
 	name := normalize(string(i), maximumLongLength-shortLength-uint32(len("tpi---")))
-	digest := hash(string(i), shortLength/2)
+	digest := hash(name, shortLength/2)
 
 	return fmt.Sprintf("tpi-%s-%s-%s", name, digest, hash(name+digest, shortLength/2))
 }

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -9,13 +9,21 @@ import (
 
 func TestIdentifier(t *testing.T) {
 	name := gofakeit.NewCrypto().Sentence(512)
-
 	t.Run("stability", func(t *testing.T) {
 		identifierOne := NewIdentifier(name)
 		identifierTwo := NewIdentifier(name)
 
 		require.Equal(t, identifierOne.Long(), identifierTwo.Long())
 		require.Equal(t, identifierOne.Short(), identifierTwo.Short())
+	})
+
+	t.Run("consistent", func(t *testing.T) {
+		identifier := NewIdentifier("5299fe10-79e9-4c3b-b15e-036e8e60ab6c")
+		parsed, err := ParseIdentifier(identifier.Long())
+
+		require.NoError(t, err)
+		require.Equal(t, identifier.Long(), parsed.Long())
+		require.Equal(t, identifier.Short(), parsed.Short())
 	})
 
 	t.Run("homogeneity", func(t *testing.T) {

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -11,10 +11,11 @@ func TestIdentifier(t *testing.T) {
 	name := gofakeit.NewCrypto().Sentence(512)
 
 	t.Run("stability", func(t *testing.T) {
-		identifier := NewIdentifier(name)
+		identifierOne := NewIdentifier(name)
+		identifierTwo := NewIdentifier(name)
 
-		require.Equal(t, identifier.Long(), identifier.Long())
-		require.Equal(t, identifier.Short(), identifier.Short())
+		require.Equal(t, identifierOne.Long(), identifierTwo.Long())
+		require.Equal(t, identifierOne.Short(), identifierTwo.Short())
 	})
 
 	t.Run("homogeneity", func(t *testing.T) {

--- a/task/common/identifier_test.go
+++ b/task/common/identifier_test.go
@@ -10,11 +10,10 @@ import (
 func TestIdentifier(t *testing.T) {
 	name := gofakeit.NewCrypto().Sentence(512)
 	t.Run("stability", func(t *testing.T) {
-		identifierOne := NewIdentifier(name)
-		identifierTwo := NewIdentifier(name)
+		identifier := NewIdentifier(name)
 
-		require.Equal(t, identifierOne.Long(), identifierTwo.Long())
-		require.Equal(t, identifierOne.Short(), identifierTwo.Short())
+		require.Equal(t, identifier.Long(), identifier.Long())
+		require.Equal(t, identifier.Short(), identifier.Short())
 	})
 
 	t.Run("consistent", func(t *testing.T) {


### PR DESCRIPTION
:hear_no_evil: Much sad! 8 hrs of debugging for such a small fix :see_no_evil:

my day's TLDR:

Any id/name greater than 28 aka: `maximumLongLength-shortLength-uint32(len("tpi---"))` resulted in improperly generating the digest and so the inferred bucket name was different from `terraform create` to `terraform refresh` which results in the follow error: 
![image](https://user-images.githubusercontent.com/1105843/182261471-a7799227-3891-4c59-944b-7719edac4370.png)


Discovered via some BB testing because below  Bitbucket CI env is a uuid and thus `>28` you can also replicate the error by setting a `name` for your task that is also `>28` chars:
https://github.com/iterative/terraform-provider-iterative/blob/c3f1c08c60d32b954e8e23b23feae2e7431100c5/iterative/resource_task.go#L371-L388