### PR TITLE
Add support for instance-permission-set in azure

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -92,7 +92,8 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 				Ports: &[]uint16{22},
 			},
 		},
-		Parallelism: uint16(1),
+		Parallelism:   uint16(1),
+		PermissionSet: o.PermissionSet,
 	}
 
 	cfg.Spot = common.Spot(common.SpotDisabled)

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -274,8 +274,8 @@ A service account email and a [list of scopes](https://cloud.google.com/sdk/gclo
 `permission_set = "sa-name@project_id.iam.gserviceaccount.com,scopes=storage-rw"`
 
 #### Microsoft Azure
-
-[Not yet implemented](https://github.com/iterative/terraform-provider-iterative/issues/559)
+A comma-separated list of [user-assigned identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) ARM resource ids, e.g.:
+`permission_set = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}"`
 
 #### Kubernetes
 

--- a/iterative/azure/provider.go
+++ b/iterative/azure/provider.go
@@ -203,6 +203,7 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 		Tags: metadata,
 		Identity: &compute.VirtualMachineIdentity{
 			UserAssignedIdentities: userAssignedIdentities,
+			Type:                   compute.ResourceIdentityTypeSystemAssignedUserAssigned,
 		},
 		Location: to.StringPtr(region),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{

--- a/iterative/resource_machine.go
+++ b/iterative/resource_machine.go
@@ -181,7 +181,7 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	cloud := d.Get("cloud").(string)
 
-	if len(d.Get("instance_permission_set").(string)) > 0 && (cloud == "azure" || cloud == "kubernetes") {
+	if len(d.Get("instance_permission_set").(string)) > 0 && (cloud == "kubernetes") {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  fmt.Sprintf("instance_permission_set is not yet supported in " + cloud),

--- a/task/az/resources/data_source_permission_set.go
+++ b/task/az/resources/data_source_permission_set.go
@@ -46,6 +46,7 @@ func (ps *PermissionSet) Read(ctx context.Context) error {
 	}
 	ps.Resource = &compute.VirtualMachineScaleSetIdentity{
 		UserAssignedIdentities: identityMap,
+		Type:                   compute.ResourceIdentityTypeSystemAssignedUserAssigned,
 	}
 	return nil
 }

--- a/task/az/resources/data_source_permission_set_test.go
+++ b/task/az/resources/data_source_permission_set_test.go
@@ -1,0 +1,31 @@
+package resources_test
+
+import (
+	"terraform-provider-iterative/task/az/resources"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestARMIDValidation tests the validation of user-assigned identity values.
+func TestARMIDValidation(t *testing.T) {
+	tests := []struct {
+		Identity    string
+		ExpectError string
+	}{{
+		Identity:    "/subscriptions/cse78759-ef49-49f7-b371-f6841fa82182/resourceGroups/resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/managed-identity",
+		ExpectError: "",
+	}, {
+		Identity:    "/subscriptions/no-valid",
+		ExpectError: `invalid user-assigned identity id: "/subscriptions/no-valid"`,
+	}}
+
+	for _, test := range tests {
+		err := resources.ValidateARMID(test.Identity)
+		if test.ExpectError == "" {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, test.ExpectError)
+		}
+	}
+}

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -110,58 +110,47 @@ type Task struct {
 
 func (t *Task) Create(ctx context.Context) error {
 	logrus.Info("Creating resources...")
-	// Define a list of steps to execute. If we adopt this pattern, we
-	// can declare a named type for the step definition.
-	steps := []struct {
-		description string
-		run         func(context.Context) error
-	}{{
-		description: "Parsing PermissionSet",
-		run:         t.DataSources.PermissionSet.Read,
-	}, {
-		description: "Creating ResourceGroup",
-		run:         t.Resources.ResourceGroup.Create,
-	}, {
-		description: "Creating StorageAccount",
-		run:         t.Resources.StorageAccount.Create,
-	}, {
-		description: "Creating BlobContainer",
-		run:         t.Resources.BlobContainer.Create,
-	}, {
-		description: "Creating Credentials",
-		run:         t.DataSources.Credentials.Read,
-	}, {
-		description: "Creating VirtualNetwork",
-		run:         t.Resources.VirtualNetwork.Create,
-	}, {
-		description: "Creating SecurityGroup",
-		run:         t.Resources.SecurityGroup.Create,
-	}, {
-		description: "Creating Subnet",
-		run:         t.Resources.Subnet.Create,
-	}, {
-		description: "Creating VirtualMachineScaleSet",
-		run:         t.Resources.VirtualMachineScaleSet.Create,
-	}, {
-		description: "Uploading Directory",
-		run: func(ctx context.Context) error {
-			// TODO: this could be cleaned up to line up with other steps better.
-			if t.Attributes.Environment.Directory != "" {
-				return t.Push(ctx, t.Attributes.Environment.Directory)
-			}
-			return nil
-		},
-	}, {
-		description: "Starting task",
-		run:         t.Start,
-	}}
-
-	totalSteps := len(steps)
-	for i, step := range steps {
-		logrus.Infof("[%d/%d] %s...", i+1, totalSteps, step.description)
-		if err := step.run(ctx); err != nil {
+	logrus.Info("[1/10] Creating ResourceGroup...")
+	if err := t.Resources.ResourceGroup.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[2/10] Creating StorageAccount...")
+	if err := t.Resources.StorageAccount.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[3/10] Creating BlobContainer...")
+	if err := t.Resources.BlobContainer.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[4/10] Creating Credentials...")
+	if err := t.DataSources.Credentials.Read(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[5/10] Creating VirtualNetwork...")
+	if err := t.Resources.VirtualNetwork.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[6/10] Creating SecurityGroup...")
+	if err := t.Resources.SecurityGroup.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[7/10] Creating Subnet...")
+	if err := t.Resources.Subnet.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[8/10] Creating VirtualMachineScaleSet...")
+	if err := t.Resources.VirtualMachineScaleSet.Create(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[9/10] Uploading Directory...")
+	if t.Attributes.Environment.Directory != "" {
+		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
 			return err
 		}
+	}
+	logrus.Info("[10/10] Starting task...")
+	if err := t.Start(ctx); err != nil {
+		return err
 	}
 	logrus.Info("Creation completed")
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -110,47 +110,58 @@ type Task struct {
 
 func (t *Task) Create(ctx context.Context) error {
 	logrus.Info("Creating resources...")
-	logrus.Info("[1/10] Creating ResourceGroup...")
-	if err := t.Resources.ResourceGroup.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/10] Creating StorageAccount...")
-	if err := t.Resources.StorageAccount.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/10] Creating BlobContainer...")
-	if err := t.Resources.BlobContainer.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[4/10] Creating Credentials...")
-	if err := t.DataSources.Credentials.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[5/10] Creating VirtualNetwork...")
-	if err := t.Resources.VirtualNetwork.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/10] Creating SecurityGroup...")
-	if err := t.Resources.SecurityGroup.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/10] Creating Subnet...")
-	if err := t.Resources.Subnet.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[8/10] Creating VirtualMachineScaleSet...")
-	if err := t.Resources.VirtualMachineScaleSet.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[9/10] Uploading Directory...")
-	if t.Attributes.Environment.Directory != "" {
-		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
+	// Define a list of steps to execute. If we adopt this pattern, we
+	// can declare a named type for the step definition.
+	steps := []struct {
+		description string
+		run         func(context.Context) error
+	}{{
+		description: "Parsing PermissionSet",
+		run:         t.DataSources.PermissionSet.Read,
+	}, {
+		description: "Creating ResourceGroup",
+		run:         t.Resources.ResourceGroup.Create,
+	}, {
+		description: "Creating StorageAccount",
+		run:         t.Resources.StorageAccount.Create,
+	}, {
+		description: "Creating BlobContainer",
+		run:         t.Resources.BlobContainer.Create,
+	}, {
+		description: "Creating Credentials",
+		run:         t.DataSources.Credentials.Read,
+	}, {
+		description: "Creating VirtualNetwork",
+		run:         t.Resources.VirtualNetwork.Create,
+	}, {
+		description: "Creating SecurityGroup",
+		run:         t.Resources.SecurityGroup.Create,
+	}, {
+		description: "Creating Subnet",
+		run:         t.Resources.Subnet.Create,
+	}, {
+		description: "Creating VirtualMachineScaleSet",
+		run:         t.Resources.VirtualMachineScaleSet.Create,
+	}, {
+		description: "Uploading Directory",
+		run: func(ctx context.Context) error {
+			// TODO: this could be cleaned up to line up with other steps better.
+			if t.Attributes.Environment.Directory != "" {
+				return t.Push(ctx, t.Attributes.Environment.Directory)
+			}
+			return nil
+		},
+	}, {
+		description: "Starting task",
+		run:         t.Start,
+	}}
+
+	totalSteps := len(steps)
+	for i, step := range steps {
+		logrus.Infof("[%d/%d] %s...", i+1, totalSteps, step.description)
+		if err := step.run(ctx); err != nil {
 			return err
 		}
-	}
-	logrus.Info("[10/10] Starting task...")
-	if err := t.Start(ctx); err != nil {
-		return err
 	}
 	logrus.Info("Creation completed")
 	t.Attributes.Addresses = t.Resources.VirtualMachineScaleSet.Attributes.Addresses

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -110,45 +110,49 @@ type Task struct {
 
 func (t *Task) Create(ctx context.Context) error {
 	logrus.Info("Creating resources...")
-	logrus.Info("[1/10] Creating ResourceGroup...")
+	logrus.Info("[1/11] Creating PermissionSet...")
+	if err := t.DataSources.PermissionSet.Read(ctx); err != nil {
+		return err
+	}
+	logrus.Info("[2/11] Creating ResourceGroup...")
 	if err := t.Resources.ResourceGroup.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[2/10] Creating StorageAccount...")
+	logrus.Info("[3/11] Creating StorageAccount...")
 	if err := t.Resources.StorageAccount.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[3/10] Creating BlobContainer...")
+	logrus.Info("[4/11] Creating BlobContainer...")
 	if err := t.Resources.BlobContainer.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[4/10] Creating Credentials...")
+	logrus.Info("[5/11] Creating Credentials...")
 	if err := t.DataSources.Credentials.Read(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[5/10] Creating VirtualNetwork...")
+	logrus.Info("[6/11] Creating VirtualNetwork...")
 	if err := t.Resources.VirtualNetwork.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[6/10] Creating SecurityGroup...")
+	logrus.Info("[7/11] Creating SecurityGroup...")
 	if err := t.Resources.SecurityGroup.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[7/10] Creating Subnet...")
+	logrus.Info("[8/11] Creating Subnet...")
 	if err := t.Resources.Subnet.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[8/10] Creating VirtualMachineScaleSet...")
+	logrus.Info("[9/11] Creating VirtualMachineScaleSet...")
 	if err := t.Resources.VirtualMachineScaleSet.Create(ctx); err != nil {
 		return err
 	}
-	logrus.Info("[9/10] Uploading Directory...")
+	logrus.Info("[10/11] Uploading Directory...")
 	if t.Attributes.Environment.Directory != "" {
 		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
 			return err
 		}
 	}
-	logrus.Info("[10/10] Starting task...")
+	logrus.Info("[11/11] Starting task...")
 	if err := t.Start(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses #559 

The instance-permission-set is parsed as a comma-separated list of ARM resource ids in the form
'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
