### PR TITLE
Use go build tags to separate task smoke tests

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -1,5 +1,5 @@
 name: build-ami
-on: 
+on:
   push:
     branches: [master]
     paths: [environment/**]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-on: 
+on:
   release:
     types: [published]
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,13 +46,13 @@ jobs:
       with:
         aws-region: us-west-1
         role-to-assume: arn:aws:iam::342840881361:role/SandboxUser
-    - run: go test ./task -v -timeout=30m -count=1
+    - run: go test ./task -v -timeout=30m -count=1 -tags=smoke_tests
     - if: always()
       uses: actions/checkout@v2
       with:
         ref: master
     - if: always()
-      run: go test ./task -v -timeout=30m -count=1
+      run: go test ./task -v -timeout=30m -count=1 -tags=smoke_tests
       env:
         SMOKE_TEST_SWEEP: true
   test-k8s:
@@ -110,7 +110,7 @@ jobs:
           -e 's/\n/%0A/g;' \
           -e 's/\r/%0D/g;' \
           -e 's/(.+)/::add-mask::\1\n::set-output name=kubeconfig::\1\n/g'
-    - run: go test ./task -v -timeout=30m -count=1
+    - run: go test ./task -v -timeout=30m -count=1 -tags=smoke_tests
       env:
         KUBECONFIG_DATA: ${{ steps.cluster.outputs.kubeconfig }}
         SMOKE_TEST_ENABLE_K8S: true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,13 +46,13 @@ jobs:
       with:
         aws-region: us-west-1
         role-to-assume: arn:aws:iam::342840881361:role/SandboxUser
-    - run: go test ./task -v -timeout=30m -count=1 -tags=smoke_tests
+    - run: go test ./task -v -timeout=30m -count=1 -tags=smoke
     - if: always()
       uses: actions/checkout@v2
       with:
         ref: master
     - if: always()
-      run: go test ./task -v -timeout=30m -count=1 -tags=smoke_tests
+      run: go test ./task -v -timeout=30m -count=1 -tags=smoke
       env:
         SMOKE_TEST_SWEEP: true
   test-k8s:
@@ -110,7 +110,7 @@ jobs:
           -e 's/\n/%0A/g;' \
           -e 's/\r/%0D/g;' \
           -e 's/(.+)/::add-mask::\1\n::set-output name=kubeconfig::\1\n/g'
-    - run: go test ./task -v -timeout=30m -count=1 -tags=smoke_tests
+    - run: go test ./task -v -timeout=30m -count=1 -tags=smoke
       env:
         KUBECONFIG_DATA: ${{ steps.cluster.outputs.kubeconfig }}
         SMOKE_TEST_ENABLE_K8S: true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	go test ./... ${TESTARGS} -timeout=30s -parallel=4 -short
 
 smoke:
-	go test ./task -v ${TESTARGS} -timeout=30m -count=1
+	go test ./task -v ${TESTARGS} -timeout=30m -count=1 -tags=smoke_tests
 
 sweep:
 	SMOKE_TEST_SWEEP=true go test ./task -v ${TESTARGS} -timeout=30m -count=1

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 	GOBIN=${INSTALL_PATH} go install
 
 test:
-	go test ./... ${TESTARGS} -timeout=30s -parallel=4 -short
+	go test ./... ${TESTARGS} -timeout=30s -parallel=4
 
 smoke:
 	go test ./task -v ${TESTARGS} -timeout=30m -count=1 -tags=smoke_tests

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	go test ./... ${TESTARGS} -timeout=30s -parallel=4
 
 smoke:
-	go test ./task -v ${TESTARGS} -timeout=30m -count=1 -tags=smoke_tests
+	go test ./task -v ${TESTARGS} -timeout=30m -count=1 -tags=smoke
 
 sweep:
 	SMOKE_TEST_SWEEP=true go test ./task -v ${TESTARGS} -timeout=30m -count=1

--- a/task/task_smoke_test.go
+++ b/task/task_smoke_test.go
@@ -1,3 +1,5 @@
+//go:build smoke_tests
+
 package task
 
 import (
@@ -17,7 +19,7 @@ import (
 	"terraform-provider-iterative/task/common"
 )
 
-func TestTask(t *testing.T) {
+func TestTaskSmokeTest(t *testing.T) {
 	if testing.Short() {
 		t.Skip("go test -short detected, skipping smoke tests")
 	}

--- a/task/task_smoke_test.go
+++ b/task/task_smoke_test.go
@@ -1,4 +1,4 @@
-//go:build smoke_tests
+//go:build smoke
 
 package task
 
@@ -19,7 +19,9 @@ import (
 	"terraform-provider-iterative/task/common"
 )
 
-func TestTaskSmokeTest(t *testing.T) {
+// TestTaskSmoke runs smoke tests with specified infrastructure providers.
+// Cloud provider access credentials (provided as environment variables) are required.
+func TestTaskSmoke(t *testing.T) {
 	testName := os.Getenv("SMOKE_TEST_IDENTIFIER")
 	sweepOnly := os.Getenv("SMOKE_TEST_SWEEP") != ""
 

--- a/task/task_smoke_test.go
+++ b/task/task_smoke_test.go
@@ -20,10 +20,6 @@ import (
 )
 
 func TestTaskSmokeTest(t *testing.T) {
-	if testing.Short() {
-		t.Skip("go test -short detected, skipping smoke tests")
-	}
-
 	testName := os.Getenv("SMOKE_TEST_IDENTIFIER")
 	sweepOnly := os.Getenv("SMOKE_TEST_SWEEP") != ""
 


### PR DESCRIPTION
There should be a clear separation of unit and smoke/integration tests.