### PR TITLE
Parse nested maps from viper configuration

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -64,8 +64,8 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 	for name, value := range o.Environment {
 		name = strings.ToUpper(name)
 		variables[name] = nil
-		if value != "" {
-			variables[name] = &value
+		if copy := value; value != "" {
+			variables[name] = &copy
 		}
 	}
 

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -62,6 +62,7 @@ func New(cloud *common.Cloud) *cobra.Command {
 func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) error {
 	variables := make(map[string]*string)
 	for name, value := range o.Environment {
+		name = strings.ToUpper(name)
 		variables[name] = nil
 		if value != "" {
 			variables[name] = &value


### PR DESCRIPTION
Closes #638; convoluted workaround to keep `cobra` instead of `viper` as the primary schema.