### PR TITLE
Restructure how resource allocation/deallocation/read steps are defined and executed

### DIFF
--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -109,54 +109,51 @@ type Task struct {
 
 func (t *Task) Create(ctx context.Context) error {
 	logrus.Info("Creating resources...")
-	logrus.Info("[1/12] Parsing PermissionSet...")
-	if err := t.DataSources.PermissionSet.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/12] Importing DefaultVPC...")
-	if err := t.DataSources.DefaultVPC.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/12] Importing DefaultVPCSubnets...")
-	if err := t.DataSources.DefaultVPCSubnets.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[4/12] Reading Image...")
-	if err := t.DataSources.Image.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[5/12] Creating Bucket...")
-	if err := t.Resources.Bucket.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/12] Creating SecurityGroup...")
-	if err := t.Resources.SecurityGroup.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/12] Creating KeyPair...")
-	if err := t.Resources.KeyPair.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[8/12] Reading Credentials...")
-	if err := t.DataSources.Credentials.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[9/12] Creating LaunchTemplate...")
-	if err := t.Resources.LaunchTemplate.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[10/12] Creating AutoScalingGroup...")
-	if err := t.Resources.AutoScalingGroup.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[11/12] Uploading Directory...")
+	steps := []common.Step{{
+		Description: "Parsing PermissionSet...",
+		Action:      t.DataSources.PermissionSet.Read,
+	}, {
+		Description: "Importing DefaultVPC...",
+		Action:      t.DataSources.DefaultVPC.Read,
+	}, {
+		Description: "Importing DefaultVPCSubnets...",
+		Action:      t.DataSources.DefaultVPCSubnets.Read,
+	}, {
+		Description: "Reading Image...",
+		Action:      t.DataSources.Image.Read,
+	}, {
+		Description: "Creating Bucket...",
+		Action:      t.Resources.Bucket.Create,
+	}, {
+		Description: "Creating SecurityGroup...",
+		Action:      t.Resources.SecurityGroup.Create,
+	}, {
+		Description: "Creating KeyPair...",
+		Action:      t.Resources.KeyPair.Create,
+	}, {
+		Description: "Reading Credentials...",
+		Action:      t.DataSources.Credentials.Read,
+	}, {
+		Description: "Creating LaunchTemplate...",
+		Action:      t.Resources.LaunchTemplate.Create,
+	}, {
+		Description: "Creating AutoScalingGroup...",
+		Action:      t.Resources.AutoScalingGroup.Create,
+	}}
+
 	if t.Attributes.Environment.Directory != "" {
-		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
-			return err
-		}
+		steps = append(steps, common.Step{
+			Description: "Uploading Directory...",
+			Action: func(ctx context.Context) error {
+				return t.Push(ctx, t.Attributes.Environment.Directory)
+			},
+		})
 	}
-	logrus.Info("[12/12] Starting task...")
-	if err := t.Start(ctx); err != nil {
+	steps = append(steps, common.Step{
+		Description: "Starting task...",
+		Action:      t.Start,
+	})
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Creation completed")
@@ -168,41 +165,36 @@ func (t *Task) Create(ctx context.Context) error {
 
 func (t *Task) Read(ctx context.Context) error {
 	logrus.Info("Reading resources... (this may happen several times)")
-	logrus.Info("[1/9] Reading DefaultVPC...")
-	if err := t.DataSources.DefaultVPC.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/9] Reading DefaultVPCSubnets...")
-	if err := t.DataSources.DefaultVPCSubnets.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/9] Reading Image...")
-	if err := t.DataSources.Image.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[4/9] Reading Bucket...")
-	if err := t.Resources.Bucket.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[5/9] Reading SecurityGroup...")
-	if err := t.Resources.SecurityGroup.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/9] Reading KeyPair...")
-	if err := t.Resources.KeyPair.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/9] Reading Credentials...")
-	if err := t.DataSources.Credentials.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[8/9] Reading LaunchTemplate...")
-	if err := t.Resources.LaunchTemplate.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[9/9] Reading AutoScalingGroup...")
-	if err := t.Resources.AutoScalingGroup.Read(ctx); err != nil {
-		return err
+	steps := []common.Step{{
+		Description: "Reading DefaultVPC...",
+		Action:      t.DataSources.DefaultVPC.Read,
+	}, {
+		Description: "Reading DefaultVPCSubnets...",
+		Action:      t.DataSources.DefaultVPCSubnets.Read,
+	}, {
+		Description: "Reading Image...",
+		Action:      t.DataSources.Image.Read,
+	}, {
+		Description: "Reading Bucket...",
+		Action:      t.Resources.Bucket.Read,
+	}, {
+		Description: "Reading SecurityGroup...",
+		Action:      t.Resources.SecurityGroup.Read,
+	}, {
+		Description: "Reading KeyPair...",
+		Action:      t.Resources.KeyPair.Read,
+	}, {
+		Description: "Reading Credentials...",
+		Action:      t.DataSources.Credentials.Read,
+	}, {
+		Description: "Reading LaunchTemplate...",
+		Action:      t.Resources.LaunchTemplate.Read,
+	}, {
+		Description: "Reading AutoScalingGroup...",
+		Action:      t.Resources.AutoScalingGroup.Read,
+	}}
+	if err := common.RunSteps(ctx, steps); err != nil {
+		return nil
 	}
 	logrus.Info("Read completed")
 	t.Attributes.Addresses = t.Resources.AutoScalingGroup.Attributes.Addresses

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -194,7 +194,7 @@ func (t *Task) Read(ctx context.Context) error {
 		Action:      t.Resources.AutoScalingGroup.Read,
 	}}
 	if err := common.RunSteps(ctx, steps); err != nil {
-		return nil
+		return err
 	}
 	logrus.Info("Read completed")
 	t.Attributes.Addresses = t.Resources.AutoScalingGroup.Attributes.Addresses

--- a/task/common/steps.go
+++ b/task/common/steps.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Step defines a single resource creation step.
+type Step struct {
+	Action      func(ctx context.Context) error
+	Description string
+}
+
+// RunSteps executes the specified resource allocation steps.
+func RunSteps(ctx context.Context, steps []Step) error {
+	total := len(steps)
+	for i, step := range steps {
+		logrus.Infof("[%d/%d] %s...", i+1, total, step.Description)
+		if err := step.Action(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/task/common/steps_test.go
+++ b/task/common/steps_test.go
@@ -1,0 +1,47 @@
+package common_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"terraform-provider-iterative/task/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSteps(t *testing.T) {
+	ctx := context.Background()
+	stepsRun := []int{}
+	steps := []common.Step{{
+		Description: "step 1",
+		Action: func(context.Context) error {
+			stepsRun = append(stepsRun, 1)
+			return nil
+		},
+	}, {
+		Description: "step 2",
+		// Step 2 returns an error.
+		Action: func(context.Context) error {
+			stepsRun = append(stepsRun, 2)
+			return errors.New("some error")
+		},
+	}, {
+		Description: "step 3",
+		Action: func(context.Context) error {
+			stepsRun = append(stepsRun, 3)
+			return nil
+		},
+	}}
+
+	// Run the only steps 1 and 3.
+	err := common.RunSteps(ctx, []common.Step{steps[0], steps[2]})
+	require.NoError(t, err)
+	require.Equal(t, stepsRun, []int{1, 3})
+
+	// Run the original test set. Since step 2 returns an error, step 3 won't be run.
+	stepsRun = []int{}
+	err = common.RunSteps(ctx, steps)
+	require.EqualError(t, err, "some error")
+	require.Equal(t, stepsRun, []int{1, 2})
+}

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -157,66 +157,59 @@ type Task struct {
 
 func (t *Task) Create(ctx context.Context) error {
 	logrus.Info("Creating resources...")
-	logrus.Info("[1/15] Parsing PermissionSet...")
-	if err := t.DataSources.PermissionSet.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/15] Creating DefaultNetwork...")
-	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/15] Reading Image...")
-	if err := t.DataSources.Image.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[4/15] Creating Bucket...")
-	if err := t.Resources.Bucket.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[5/15] Reading Credentials...")
-	if err := t.DataSources.Credentials.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/15] Creating FirewallInternalEgress...")
-	if err := t.Resources.FirewallInternalEgress.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/15] Creating FirewallInternalIngress...")
-	if err := t.Resources.FirewallInternalIngress.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[8/15] Creating FirewallExternalEgress...")
-	if err := t.Resources.FirewallExternalEgress.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[9/15] Creating FirewallExternalIngress...")
-	if err := t.Resources.FirewallExternalIngress.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[10/15] Creating FirewallDenyEgress...")
-	if err := t.Resources.FirewallDenyEgress.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[11/15] Creating FirewallDenyIngress...")
-	if err := t.Resources.FirewallDenyIngress.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[12/15] Creating InstanceTemplate...")
-	if err := t.Resources.InstanceTemplate.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[13/15] Creating InstanceGroupManager...")
-	if err := t.Resources.InstanceGroupManager.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[14/15] Uploading Directory...")
+	steps := []common.Step{{
+		Description: "Parsing PermissionSet...",
+		Action:      t.DataSources.PermissionSet.Read,
+	}, {
+		Description: "Creating DefaultNetwork...",
+		Action:      t.DataSources.DefaultNetwork.Read,
+	}, {
+		Description: "Reading Image...",
+		Action:      t.DataSources.Image.Read,
+	}, {
+		Description: "Creating Bucket...",
+		Action:      t.Resources.Bucket.Create,
+	}, {
+		Description: "Reading Credentials...",
+		Action:      t.DataSources.Credentials.Read,
+	}, {
+		Description: "Creating FirewallInternalEgress...",
+		Action:      t.Resources.FirewallInternalEgress.Create,
+	}, {
+		Description: "Creating FirewallInternalIngress...",
+		Action:      t.Resources.FirewallInternalIngress.Create,
+	}, {
+		Description: "Creating FirewallExternalEgress...",
+		Action:      t.Resources.FirewallExternalEgress.Create,
+	}, {
+		Description: "Creating FirewallExternalIngress...",
+		Action:      t.Resources.FirewallExternalIngress.Create,
+	}, {
+		Description: "Creating FirewallDenyEgress...",
+		Action:      t.Resources.FirewallDenyEgress.Create,
+	}, {
+		Description: "Creating FirewallDenyIngress...",
+		Action:      t.Resources.FirewallDenyIngress.Create,
+	}, {
+		Description: "Creating InstanceTemplate...",
+		Action:      t.Resources.InstanceTemplate.Create,
+	}, {
+		Description: "Creating InstanceGroupManager...",
+		Action:      t.Resources.InstanceGroupManager.Create,
+	}}
+
 	if t.Attributes.Environment.Directory != "" {
-		if err := t.Push(ctx, t.Attributes.Environment.Directory); err != nil {
-			return err
-		}
+		steps = append(steps, common.Step{
+			Description: "Uploading Directory...",
+			Action: func(ctx context.Context) error {
+				return t.Push(ctx, t.Attributes.Environment.Directory)
+			}})
 	}
-	logrus.Info("[15/15] Starting task...")
-	if err := t.Start(ctx); err != nil {
+	steps = append(steps, common.Step{
+		Description: "Starting task...",
+		Action:      t.Start,
+	})
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Creation completed")
@@ -228,52 +221,44 @@ func (t *Task) Create(ctx context.Context) error {
 
 func (t *Task) Read(ctx context.Context) error {
 	logrus.Info("Reading resources... (this may happen several times)")
-	logrus.Info("[1/12] Reading DefaultNetwork...")
-	if err := t.DataSources.DefaultNetwork.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/12] Reading Image...")
-	if err := t.DataSources.Image.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/12] Reading Bucket...")
-	if err := t.Resources.Bucket.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[4/12] Reading Credentials...")
-	if err := t.DataSources.Credentials.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[5/12] Reading FirewallInternalEgress...")
-	if err := t.Resources.FirewallInternalEgress.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/12] Reading FirewallInternalIngress...")
-	if err := t.Resources.FirewallInternalIngress.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/12] Reading FirewallExternalEgress...")
-	if err := t.Resources.FirewallExternalEgress.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[8/12] Reading FirewallExternalIngress...")
-	if err := t.Resources.FirewallExternalIngress.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[9/12] Reading FirewallDenyEgress...")
-	if err := t.Resources.FirewallDenyEgress.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[10/12] Reading FirewallDenyIngress...")
-	if err := t.Resources.FirewallDenyIngress.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[11/12] Reading InstanceTemplate...")
-	if err := t.Resources.InstanceTemplate.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[12/12] Reading InstanceGroupManager...")
-	if err := t.Resources.InstanceGroupManager.Read(ctx); err != nil {
+	steps := []common.Step{{
+		Description: "Reading DefaultNetwork...",
+		Action:      t.DataSources.DefaultNetwork.Read,
+	}, {
+		Description: "Reading Image...",
+		Action:      t.DataSources.Image.Read,
+	}, {
+		Description: "Reading Bucket...",
+		Action:      t.Resources.Bucket.Read,
+	}, {
+		Description: "Reading Credentials...",
+		Action:      t.DataSources.Credentials.Read,
+	}, {
+		Description: "Reading FirewallInternalEgress...",
+		Action:      t.Resources.FirewallInternalEgress.Read,
+	}, {
+		Description: "Reading FirewallInternalIngress...",
+		Action:      t.Resources.FirewallInternalIngress.Read,
+	}, {
+		Description: "Reading FirewallExternalEgress...",
+		Action:      t.Resources.FirewallExternalEgress.Read,
+	}, {
+		Description: "Reading FirewallExternalIngress...",
+		Action:      t.Resources.FirewallExternalIngress.Read,
+	}, {
+		Description: "Reading FirewallDenyEgress...",
+		Action:      t.Resources.FirewallDenyEgress.Read,
+	}, {
+		Description: "Reading FirewallDenyIngress...",
+		Action:      t.Resources.FirewallDenyIngress.Read,
+	}, {
+		Description: "Reading InstanceTemplate...",
+		Action:      t.Resources.InstanceTemplate.Read,
+	}, {
+		Description: "Reading InstanceGroupManager...",
+		Action:      t.Resources.InstanceGroupManager.Read,
+	}}
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Read completed")
@@ -285,52 +270,59 @@ func (t *Task) Read(ctx context.Context) error {
 
 func (t *Task) Delete(ctx context.Context) error {
 	logrus.Info("Deleting resources...")
-	logrus.Info("[1/11] Downloading Directory...")
+	steps := []common.Step{}
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
-			if err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut); err != nil && err != common.NotFoundError {
-				return err
-			}
+			steps = []common.Step{{
+				Description: "Downloading Directory...",
+				Action: func(ctx context.Context) error {
+					err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut)
+					if err != nil && err != common.NotFoundError {
+						return err
+					}
+					return nil
+				},
+			}, {
+				Description: "Emptying Bucket...",
+				Action: func(ctx context.Context) error {
+					err := machine.Delete(ctx, t.DataSources.Credentials.Resource["RCLONE_REMOTE"])
+					if err != nil && err != common.NotFoundError {
+						return err
+					}
+					return nil
+				},
+			}}
 		}
-		logrus.Info("[2/11] Emptying Bucket...")
-		if err := machine.Delete(ctx, t.DataSources.Credentials.Resource["RCLONE_REMOTE"]); err != nil && err != common.NotFoundError {
-			return err
-		}
 	}
-	logrus.Info("[3/11] Deleting InstanceGroupManager...")
-	if err := t.Resources.InstanceGroupManager.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[4/11] Deleting InstanceTemplate...")
-	if err := t.Resources.InstanceTemplate.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[5/11] Deleting FirewallInternalEgress...")
-	if err := t.Resources.FirewallInternalEgress.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/11] Deleting FirewallInternalIngress...")
-	if err := t.Resources.FirewallInternalIngress.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/11] Deleting FirewallExternalEgress...")
-	if err := t.Resources.FirewallExternalEgress.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[8/11] Deleting FirewallExternalIngress...")
-	if err := t.Resources.FirewallExternalIngress.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[9/11] Deleting FirewallDenyEgress...")
-	if err := t.Resources.FirewallDenyEgress.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[10/11] Deleting FirewallDenyIngress...")
-	if err := t.Resources.FirewallDenyIngress.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[11/11] Deleting Bucket...")
-	if err := t.Resources.Bucket.Delete(ctx); err != nil {
+	steps = append(steps, []common.Step{{
+		Description: "Deleting InstanceGroupManager...",
+		Action:      t.Resources.InstanceGroupManager.Delete,
+	}, {
+		Description: "Deleting InstanceTemplate...",
+		Action:      t.Resources.InstanceTemplate.Delete,
+	}, {
+		Description: "Deleting FirewallInternalEgress...",
+		Action:      t.Resources.FirewallInternalEgress.Delete,
+	}, {
+		Description: "Deleting FirewallInternalIngress...",
+		Action:      t.Resources.FirewallInternalIngress.Delete,
+	}, {
+		Description: "Deleting FirewallExternalEgress...",
+		Action:      t.Resources.FirewallExternalEgress.Delete,
+	}, {
+		Description: "Deleting FirewallExternalIngress...",
+		Action:      t.Resources.FirewallExternalIngress.Delete,
+	}, {
+		Description: "Deleting FirewallDenyEgress...",
+		Action:      t.Resources.FirewallDenyEgress.Delete,
+	}, {
+		Description: "Deleting FirewallDenyIngress...",
+		Action:      t.Resources.FirewallDenyIngress.Delete,
+	}, {
+		Description: "Deleting Bucket...",
+		Action:      t.Resources.Bucket.Delete,
+	}}...)
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Deletion completed")

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -202,8 +202,9 @@ func (t *Task) Delete(ctx context.Context) error {
 				return t.Pull(ctx, t.Attributes.Directory, t.Attributes.DirectoryOut)
 			}),
 		}, {
+			// WTH?
 			Description: "Deleting ephemeral Job to retrieve directory...",
-			Action:      withEnv(env, t.Resources.Job.Delete),
+			Action:      withEnv(env, t.Resources.Job.Create),
 		}}
 	}
 

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -113,45 +113,42 @@ type Task struct {
 
 func (t *Task) Create(ctx context.Context) error {
 	logrus.Info("Creating resources...")
-	logrus.Info("[1/8] Parsing PermissionSet...")
-	if err := t.DataSources.PermissionSet.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/8] Creating ConfigMap...")
-	if err := t.Resources.ConfigMap.Create(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/8] Creating PersistentVolumeClaim...")
-	if err := t.Resources.PersistentVolumeClaim.Create(ctx); err != nil {
-		return err
-	}
+	steps := []common.Step{{
+		Description: "Parsing PermissionSet...",
+		Action:      t.DataSources.PermissionSet.Read,
+	}, {
+		Description: "Creating ConfigMap...",
+		Action:      t.Resources.ConfigMap.Create,
+	}, {
+		Description: "Creating PersistentVolumeClaim...",
+		Action:      t.Resources.PersistentVolumeClaim.Create,
+	}}
 
 	if t.Attributes.Directory != "" {
 		os.Setenv("TPI_TRANSFER_MODE", "true")
 		defer os.Unsetenv("TPI_TRANSFER_MODE")
-
-		logrus.Info("[4/8] Deleting Job...")
-		if err := t.Resources.Job.Delete(ctx); err != nil {
-			return err
-		}
-		logrus.Info("[5/8] Creating ephemeral Job to upload directory...")
-		if err := t.Resources.Job.Create(ctx); err != nil {
-			return err
-		}
-		logrus.Info("[6/8] Uploading Directory...")
-		if err := t.Push(ctx, t.Attributes.Directory); err != nil {
-			return err
-		}
-		logrus.Info("[7/8] Deleting ephemeral Job to upload directory...")
-		if err := t.Resources.Job.Delete(ctx); err != nil {
-			return err
-		}
-
-		os.Unsetenv("TPI_TRANSFER_MODE")
+		steps = append(steps, []common.Step{{
+			Description: "Deleting Job...",
+			Action:      t.Resources.Job.Delete,
+		}, {
+			Description: "Creating ephemeral Job to upload directory...",
+			Action:      t.Resources.Job.Create,
+		}, {
+			Description: "Uploading Directory...",
+			Action: func(ctx context.Context) error {
+				return t.Push(ctx, t.Attributes.Directory)
+			},
+		}, {
+			Description: "Deleting ephemeral Job to upload directory...",
+			Action:      t.Resources.Job.Delete,
+		}}...)
 	}
 
-	logrus.Info("[8/8] Creating Job...")
-	if err := t.Resources.Job.Create(ctx); err != nil {
+	steps = append(steps, common.Step{
+		Description: "Creating Job...",
+		Action:      t.Resources.Job.Create,
+	})
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Creation completed")
@@ -163,16 +160,17 @@ func (t *Task) Create(ctx context.Context) error {
 
 func (t *Task) Read(ctx context.Context) error {
 	logrus.Info("Reading resources... (this may happen several times)")
-	logrus.Info("[1/3] Reading ConfigMap...")
-	if err := t.Resources.ConfigMap.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[2/3] Reading PersistentVolumeClaim...")
-	if err := t.Resources.PersistentVolumeClaim.Read(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[3/3] Reading Job...")
-	if err := t.Resources.Job.Read(ctx); err != nil {
+	steps := []common.Step{{
+		Description: "Reading ConfigMap...",
+		Action:      t.Resources.ConfigMap.Read,
+	}, {
+		Description: "Reading PersistentVolumeClaim...",
+		Action:      t.Resources.PersistentVolumeClaim.Read,
+	}, {
+		Description: "Reading Job...",
+		Action:      t.Resources.Job.Read,
+	}}
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Read completed")
@@ -184,44 +182,44 @@ func (t *Task) Read(ctx context.Context) error {
 
 func (t *Task) Delete(ctx context.Context) error {
 	logrus.Info("Deleting resources...")
+	steps := []common.Step{}
 	if t.Attributes.DirectoryOut != "" && t.Read(ctx) == nil {
 		os.Setenv("TPI_TRANSFER_MODE", "true")
 		os.Setenv("TPI_PULL_MODE", "true")
 		defer os.Unsetenv("TPI_TRANSFER_MODE")
 		defer os.Unsetenv("TPI_PULL_MODE")
 
-		logrus.Info("[1/7] Deleting Job...")
-		if err := t.Resources.Job.Delete(ctx); err != nil {
-			return err
-		}
-		logrus.Info("[2/7] Creating ephemeral Job to retrieve directory...")
-		if err := t.Resources.Job.Create(ctx); err != nil {
-			return err
-		}
-		logrus.Info("[3/7] Downloading Directory...")
-		if err := t.Pull(ctx, t.Attributes.Directory, t.Attributes.DirectoryOut); err != nil {
-			return err
-		}
-
-		logrus.Info("[4/7] Deleting ephemeral Job to retrieve directory...")
-		if err := t.Resources.Job.Create(ctx); err != nil {
-			return err
-		}
+		steps = []common.Step{{
+			Description: "Deleting Job...",
+			Action:      t.Resources.Job.Delete,
+		}, {
+			Description: "Creating ephemeral Job to retrieve directory...",
+			Action:      t.Resources.Job.Create,
+		}, {
+			Description: "Downloading Directory...",
+			Action: func(ctx context.Context) error {
+				return t.Pull(ctx, t.Attributes.Directory, t.Attributes.DirectoryOut)
+			},
+		}, {
+			Description: "Deleting ephemeral Job to retrieve directory...",
+			Action:      t.Resources.Job.Create,
+		}}
 
 		os.Unsetenv("TPI_TRANSFER_MODE")
 		os.Unsetenv("TPI_PULL_MODE")
 	}
 
-	logrus.Info("[5/7] Deleting Job...")
-	if err := t.Resources.Job.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[6/7] Deleting PersistentVolumeClaim...")
-	if err := t.Resources.PersistentVolumeClaim.Delete(ctx); err != nil {
-		return err
-	}
-	logrus.Info("[7/7] Deleting ConfigMap...")
-	if err := t.Resources.ConfigMap.Delete(ctx); err != nil {
+	steps = append(steps, []common.Step{{
+		Description: "Deleting Job...",
+		Action:      t.Resources.Job.Delete,
+	}, {
+		Description: "Deleting PersistentVolumeClaim...",
+		Action:      t.Resources.PersistentVolumeClaim.Delete,
+	}, {
+		Description: "Deleting ConfigMap...",
+		Action:      t.Resources.ConfigMap.Delete,
+	}}...)
+	if err := common.RunSteps(ctx, steps); err != nil {
 		return err
 	}
 	logrus.Info("Deletion completed")


### PR DESCRIPTION
Defining steps as a slice of structures at least removes the necessity
to renumber the progress indicator when inserting new steps (or removin
them).