### PR TITLE
add gcr/gcp docker helper

### DIFF
--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -20,6 +20,9 @@ if [ ! -f "$FILE" ]; then
 
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
+    
+  curl -fsSL --max-time 10 https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
+  sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"

--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -7,7 +7,7 @@ echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assume
 
 sudo apt remove unattended-upgrades
 systemctl disable apt-daily-upgrade.service
-  
+
 FILE=/var/log/cml_stack.log
 if [ ! -f "$FILE" ]; then
   sudo add-apt-repository universe -y
@@ -20,7 +20,7 @@ if [ ! -f "$FILE" ]; then
 
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
-    
+
   curl --max-time 10 --location https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
   sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 

--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -21,7 +21,7 @@ if [ ! -f "$FILE" ]; then
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
     
-  curl -fsSL --max-time 10 https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
+  curl --max-time 10 --location https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
   sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -

--- a/iterative/testdata/script_template_cloud_aws.golden
+++ b/iterative/testdata/script_template_cloud_aws.golden
@@ -8,7 +8,7 @@ echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assume
 
 sudo apt remove unattended-upgrades
 systemctl disable apt-daily-upgrade.service
-  
+
 FILE=/var/log/cml_stack.log
 if [ ! -f "$FILE" ]; then
   sudo add-apt-repository universe -y
@@ -21,6 +21,9 @@ if [ ! -f "$FILE" ]; then
 
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
+
+  curl --max-time 10 --location https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
+  sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"

--- a/iterative/testdata/script_template_cloud_azure.golden
+++ b/iterative/testdata/script_template_cloud_azure.golden
@@ -8,7 +8,7 @@ echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assume
 
 sudo apt remove unattended-upgrades
 systemctl disable apt-daily-upgrade.service
-  
+
 FILE=/var/log/cml_stack.log
 if [ ! -f "$FILE" ]; then
   sudo add-apt-repository universe -y
@@ -21,6 +21,9 @@ if [ ! -f "$FILE" ]; then
 
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
+
+  curl --max-time 10 --location https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
+  sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"

--- a/iterative/testdata/script_template_cloud_gcp.golden
+++ b/iterative/testdata/script_template_cloud_gcp.golden
@@ -8,7 +8,7 @@ echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assume
 
 sudo apt remove unattended-upgrades
 systemctl disable apt-daily-upgrade.service
-  
+
 FILE=/var/log/cml_stack.log
 if [ ! -f "$FILE" ]; then
   sudo add-apt-repository universe -y
@@ -21,6 +21,9 @@ if [ ! -f "$FILE" ]; then
 
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
+
+  curl --max-time 10 --location https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
+  sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"

--- a/iterative/testdata/script_template_cloud_invalid.golden
+++ b/iterative/testdata/script_template_cloud_invalid.golden
@@ -8,7 +8,7 @@ echo "APT::Get::Assume-Yes \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90assume
 
 sudo apt remove unattended-upgrades
 systemctl disable apt-daily-upgrade.service
-  
+
 FILE=/var/log/cml_stack.log
 if [ ! -f "$FILE" ]; then
   sudo add-apt-repository universe -y
@@ -21,6 +21,9 @@ if [ ! -f "$FILE" ]; then
 
   sudo curl --max-time 10 --output /usr/bin/docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.5.0/linux-amd64/docker-credential-ecr-login
   sudo chmod a+x /usr/bin/docker-credential-ecr-login
+
+  curl --max-time 10 --location https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.5/docker-credential-gcr_linux_amd64-2.1.5.tar.gz | sudo tar xz docker-credential-gcr
+  sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"


### PR DESCRIPTION
similar to the ecr/aws use case.

where gitlab-ci `DOCKER_AUTH_CONFIG`:
```yml
{"credHelpers": { "us-west1-docker.pkg.dev": "gcr"}}
```
```
stages:
  - deploy
  - train

deploy_job:
  stage: deploy
  when: always
  image: iterativeai/cml
  script:
    - cml-runner
      --cloud gcp
      --cloud-region us-west
      --cloud-type e2-highcpu-2
      --cloud-permission-set=permission-set-test@cml-gcp-test.iam.gserviceaccount.com,scopes=storage-rw 
      --labels=cml-runner

train_job:
  stage: train
  when: on_success
  needs: [deploy_job]
  image: us-west1-docker.pkg.dev/cml-gcp-test/cml-test/cml:latest
  tags:
    - cml-runner
  script:
    - echo "hello"
    - cml --version
```
related: https://github.com/iterative/terraform-provider-iterative/issues/627

when published/released closes: https://github.com/iterative/cml/issues/1136