### PR TITLE
Fix identities on Microsoft Azure runners

### DIFF
--- a/iterative/azure/provider.go
+++ b/iterative/azure/provider.go
@@ -207,10 +207,6 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 	vmClient, _ := getVMClient(subscriptionID)
 	vmSettings := compute.VirtualMachine{
 		Tags: metadata,
-		Identity: &compute.VirtualMachineIdentity{
-			UserAssignedIdentities: userAssignedIdentities,
-			Type:                   compute.ResourceIdentityTypeSystemAssignedUserAssigned,
-		},
 		Location: to.StringPtr(region),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
@@ -259,6 +255,13 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 				},
 			},
 		},
+	}
+	
+	if userAssignedIdentities != nil {
+		vmSettings.Identity = &compute.VirtualMachineIdentity{
+			UserAssignedIdentities: userAssignedIdentities,
+			Type:                   compute.ResourceIdentityTypeSystemAssignedUserAssigned,
+		}
 	}
 
 	if spot {


### PR DESCRIPTION
As per discord/tpi#1014906941308403803, it seems like #632 broke runners on Microsoft Azure. 🙈 

```
Error: Failed creating the machine: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="MissingIdentityIds" Message="The identity ids must not be null or empty for 'UserAssigned' identity type."
```