### PR TITLE
Print identifier before creating resources

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -119,6 +119,8 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		return err
 	}
 
+	fmt.Println(id.Long())
+	
 	if err := tsk.Create(ctx); err != nil {
 		logrus.Errorf("Failed to create a new task: %v", err)
 		logrus.Warn("Attempting to delete residual resources...")
@@ -129,6 +131,5 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		return err
 	}
 
-	fmt.Println(id.Long())
 	return nil
 }


### PR DESCRIPTION
Suggested by @tasdomas, simplifies manual cleanup if the process fails