### PR TITLE
Fix k8s tag propagation and controller-uid detection

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -69,6 +69,8 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		}
 	}
 
+	cloud.Tags = o.Tags
+
 	script := o.Script
 	if !strings.HasPrefix(script, "#!") {
 		script = "#!/bin/sh\n" + script

--- a/iterative/kubernetes/provider.go
+++ b/iterative/kubernetes/provider.go
@@ -140,7 +140,7 @@ func ResourceMachineCreate(ctx context.Context, d *terraform_schema.ResourceData
 	log.Printf("[INFO] Submitted new job: %#v", out)
 
 	// Get the controller unique identifier for the job, so we can easily find the pods it creates.
-	waitSelector := fmt.Sprintf("controller-uid=%s", out.GetObjectMeta().GetLabels()["controller-uid"])
+	waitSelector := fmt.Sprintf("controller-uid=%s", out.Spec.Selector.MatchLabels["controller-uid"])
 
 	// Wait for the job to satisfy the readiness condition specified through kubernetes_readiness_command.
 	return terraform_resource.Retry(d.Timeout(terraform_schema.TimeoutCreate), func() *terraform_resource.RetryError {
@@ -414,7 +414,7 @@ func ResourceMachineLogs(ctx context.Context, d *terraform_schema.ResourceData, 
 	}
 
 	pods, err := conn.CoreV1().Pods(namespace).List(ctx, kubernetes_meta.ListOptions{
-		LabelSelector: fmt.Sprintf("controller-uid=%s", job.GetObjectMeta().GetLabels()["controller-uid"]),
+		LabelSelector: fmt.Sprintf("controller-uid=%s", job.Spec.Selector.MatchLabels["controller-uid"]),
 	})
 	if err != nil {
 		return "", err

--- a/task/aws/task.go
+++ b/task/aws/task.go
@@ -23,7 +23,7 @@ func List(ctx context.Context, cloud common.Cloud) ([]common.Identifier, error) 
 }
 
 func New(ctx context.Context, cloud common.Cloud, identifier common.Identifier, task common.Task) (*Task, error) {
-	client, err := client.New(ctx, cloud, task.Tags)
+	client, err := client.New(ctx, cloud, cloud.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/task/az/resources/resource_virtual_machine_scale_set.go
+++ b/task/az/resources/resource_virtual_machine_scale_set.go
@@ -28,7 +28,6 @@ func NewVirtualMachineScaleSet(client *client.Client, identifier common.Identifi
 	v.Attributes.Size = task.Size
 	v.Attributes.Environment = task.Environment
 	v.Attributes.Firewall = task.Firewall
-	v.Attributes.Tags = task.Tags
 	v.Attributes.Parallelism = &task.Parallelism
 	v.Attributes.Spot = float64(task.Spot)
 	v.Dependencies.ResourceGroup = resourceGroup
@@ -46,7 +45,6 @@ type VirtualMachineScaleSet struct {
 		Size        common.Size
 		Environment common.Environment
 		Firewall    common.Firewall
-		Tags        map[string]string
 		Parallelism *uint16
 		Spot        float64
 		Addresses   []net.IP

--- a/task/az/task.go
+++ b/task/az/task.go
@@ -23,7 +23,7 @@ func List(ctx context.Context, cloud common.Cloud) ([]common.Identifier, error) 
 }
 
 func New(ctx context.Context, cloud common.Cloud, identifier common.Identifier, task common.Task) (*Task, error) {
-	client, err := client.New(ctx, cloud, task.Tags)
+	client, err := client.New(ctx, cloud, cloud.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -137,10 +137,10 @@ func (t *Task) Create(ctx context.Context) error {
 	}}
 	if t.Attributes.Environment.Directory != "" {
 		steps = append(steps, common.Step{
-		Description: "Uploading Directory...",
-		Action: func(ctx context.Context) error {
+			Description: "Uploading Directory...",
+			Action: func(ctx context.Context) error {
 				return t.Push(ctx, t.Attributes.Environment.Directory)
-		},
+			},
 		})
 	}
 	steps = append(steps, common.Step{
@@ -201,8 +201,8 @@ func (t *Task) Delete(ctx context.Context) error {
 	if t.Read(ctx) == nil {
 		if t.Attributes.Environment.DirectoryOut != "" {
 			steps = []common.Step{{
-				Description: 	"Downloading Directory...",
-				Action: func(ctx context.Context)error {
+				Description: "Downloading Directory...",
+				Action: func(ctx context.Context) error {
 					err := t.Pull(ctx, t.Attributes.Environment.Directory, t.Attributes.Environment.DirectoryOut)
 					if err != nil && err != common.NotFoundError {
 						return err
@@ -211,7 +211,7 @@ func (t *Task) Delete(ctx context.Context) error {
 				},
 			}, {
 				Description: "Emptying Bucket...",
-				Action: func(ctx context.Context)error {
+				Action: func(ctx context.Context) error {
 					err := machine.Delete(ctx, t.DataSources.Credentials.Resource["RCLONE_REMOTE"])
 					if err != nil && err != common.NotFoundError {
 						return err
@@ -219,28 +219,29 @@ func (t *Task) Delete(ctx context.Context) error {
 					return nil
 				},
 			}}
-		}}
+		}
+	}
 	steps = append(steps, []common.Step{{
 		Description: "Deleting VirtualMachineScaleSet...",
-		Action: t.Resources.VirtualMachineScaleSet.Delete,
-	},{
+		Action:      t.Resources.VirtualMachineScaleSet.Delete,
+	}, {
 		Description: "Deleting Subnet...",
-		Action: t.Resources.Subnet.Delete,
+		Action:      t.Resources.Subnet.Delete,
 	}, {
 		Description: "Deleting SecurityGroup...",
-		Action: t.Resources.SecurityGroup.Delete,
+		Action:      t.Resources.SecurityGroup.Delete,
 	}, {
 		Description: "Deleting VirtualNetwork...",
-		Action: t.Resources.VirtualNetwork.Delete,
+		Action:      t.Resources.VirtualNetwork.Delete,
 	}, {
 		Description: "Deleting BlobContainer...",
-		Action: t.Resources.BlobContainer.Delete,
+		Action:      t.Resources.BlobContainer.Delete,
 	}, {
 		Description: "Deleting StorageAccount...",
-		Action: t.Resources.StorageAccount.Delete,
+		Action:      t.Resources.StorageAccount.Delete,
 	}, {
 		Description: "Deleting ResourceGroup...",
-		Action: t.Resources.ResourceGroup.Delete,
+		Action:      t.Resources.ResourceGroup.Delete,
 	}}...)
 	if err := common.RunSteps(ctx, steps); err != nil {
 		return err

--- a/task/common/values.go
+++ b/task/common/values.go
@@ -50,7 +50,6 @@ type Task struct {
 	PermissionSet string
 	Spot          Spot
 	Parallelism   uint16
-	Tags          map[string]string // Deprecated
 
 	Addresses []net.IP
 	Status    Status

--- a/task/gcp/task.go
+++ b/task/gcp/task.go
@@ -23,7 +23,7 @@ func List(ctx context.Context, cloud common.Cloud) ([]common.Identifier, error) 
 }
 
 func New(ctx context.Context, cloud common.Cloud, identifier common.Identifier, task common.Task) (*Task, error) {
-	client, err := client.New(ctx, cloud, task.Tags)
+	client, err := client.New(ctx, cloud, cloud.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/task/k8s/resources/resource_job.go
+++ b/task/k8s/resources/resource_job.go
@@ -337,7 +337,7 @@ func (j *Job) Delete(ctx context.Context) error {
 
 func (j *Job) Logs(ctx context.Context) ([]string, error) {
 	pods, err := j.Client.Services.Core.Pods(j.Client.Namespace).List(ctx, kubernetes_meta.ListOptions{
-		LabelSelector: fmt.Sprintf("controller-uid=%s", j.Resource.GetObjectMeta().GetLabels()["controller-uid"]),
+		LabelSelector: fmt.Sprintf("controller-uid=%s", j.Resource.Spec.Selector.MatchLabels["controller-uid"]),
 	})
 	if err != nil {
 		return nil, err

--- a/task/k8s/task.go
+++ b/task/k8s/task.go
@@ -34,7 +34,7 @@ func List(ctx context.Context, cloud common.Cloud) ([]common.Identifier, error) 
 }
 
 func New(ctx context.Context, cloud common.Cloud, identifier common.Identifier, task common.Task) (*Task, error) {
-	client, err := client.New(ctx, cloud, task.Tags)
+	client, err := client.New(ctx, cloud, cloud.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (t *Task) Delete(ctx context.Context) error {
 }
 
 func (t *Task) Push(ctx context.Context, source string) error {
-	waitSelector := fmt.Sprintf("controller-uid=%s", t.Resources.Job.Resource.GetObjectMeta().GetLabels()["controller-uid"])
+	waitSelector := fmt.Sprintf("controller-uid=%s", t.Resources.Job.Resource.Spec.Selector.MatchLabels["controller-uid"])
 	pod, err := resources.WaitForPods(ctx, t.Client, 1*time.Second, t.Client.Cloud.Timeouts.Create, t.Client.Namespace, waitSelector)
 	if err != nil {
 		return err
@@ -241,7 +241,7 @@ func (t *Task) Push(ctx context.Context, source string) error {
 }
 
 func (t *Task) Pull(ctx context.Context, destination, include string) error {
-	waitSelector := fmt.Sprintf("controller-uid=%s", t.Resources.Job.Resource.GetObjectMeta().GetLabels()["controller-uid"])
+	waitSelector := fmt.Sprintf("controller-uid=%s", t.Resources.Job.Resource.Spec.Selector.MatchLabels["controller-uid"])
 	pod, err := resources.WaitForPods(ctx, t.Client, 1*time.Second, t.Client.Cloud.Timeouts.Delete, t.Client.Namespace, waitSelector)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Purpose
* K8s tags are currently being pulled from the `Task` object (where they are always empty) instead of the correct `Cloud` object.
* When custom label are added to a k8s job, the automatically added controller-uid label disappears from the `ObjectMeta`, which then breaks things like waiting for the job to be created, etc.

## Approach
* Pull the tags from `Cloud`
* Use the job's `Spec.Selector.MatchLabels` instead of `ObjectMeta` to retrieve `controller-uid`

## Logs
This is what `kubectl describe job` shows on master:

**Without custom labels/tags:**
```yaml
Labels:         controller-uid=5cf76b42-cbc8-484a-b496-6b867182e523
                job-name=tpi-3aw4vu6287ot1-2biu93iu-1tw3q6af
Annotations:    batch.kubernetes.io/job-tracking: 
```
**With labels:**
```yaml
Labels:         app.kubernetes.io/instance=jenkins
Annotations:    app.kubernetes.io/instance: jenkins
                batch.kubernetes.io/job-tracking: 
```
