### PR TITLE
Use `region` field as comma-delimited node selector for k8s

### DIFF
--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -54,7 +54,7 @@ resource "iterative_task" "example" {
 
 ### Optional
 
-- `region` - (Optional) [Cloud region/zone](#cloud-region) to run the task on.
+- `region` - (Optional) [Cloud region/zone](#cloud-region) to run the task on, or node selector labels for kubernetes.
 - `machine` - (Optional) See [Machine Types](#machine-type) below.
 - `disk_size` - (Optional) Size of the ephemeral machine storage in GB. `-1`: automatic based on `image`.
 - `spot` - (Optional) Spot instance price. `-1`: disabled, `0`: automatic price, any other positive number: maximum bidding price in USD per hour (above which the instance is terminated until the price drops).
@@ -257,7 +257,25 @@ In addition to generic regions, it's possible to specify any cloud region suppor
 
 ### Kubernetes
 
-The `region` attribute is ignored.
+For kubernetes, the `region` attribute can be used to set the `nodeSelector` field of the job spec. The value of `region` should be a comma-delimited list of `key=value` nodel label pairs.
+
+For example:
+```tf
+resource "iterative_task" "example" {
+  cloud  = "k8s"
+  region = "foo=bar,goo=baz"
+}
+```
+
+This will create a pod with a `nodeSelector` value like the following:
+```yaml
+apiVersion: V1
+kind: Pod
+spec:
+  nodeSelector:
+    foo: bar
+    goo: baz
+```
 
 ## Permission Set
 
@@ -284,10 +302,6 @@ A comma-separated list of [user-assigned identity](https://docs.microsoft.com/en
 ## Known Issues
 
 ### Kubernetes
-
-#### Region attribute
-
-Setting the `region` attribute results in undefined behaviour.
 
 #### Directory storage
 

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -54,7 +54,7 @@ resource "iterative_task" "example" {
 
 ### Optional
 
-- `region` - (Optional) [Cloud region/zone](#cloud-region) to run the task on, or node selector labels for kubernetes.
+- `region` - (Optional) [Cloud region/zone](#cloud-region) to run the task on, or node selector labels for Kubernetes.
 - `machine` - (Optional) See [Machine Types](#machine-type) below.
 - `disk_size` - (Optional) Size of the ephemeral machine storage in GB. `-1`: automatic based on `image`.
 - `spot` - (Optional) Spot instance price. `-1`: disabled, `0`: automatic price, any other positive number: maximum bidding price in USD per hour (above which the instance is terminated until the price drops).
@@ -257,7 +257,7 @@ In addition to generic regions, it's possible to specify any cloud region suppor
 
 ### Kubernetes
 
-For kubernetes, the `region` attribute can be used to set the `nodeSelector` field of the job spec. The value of `region` should be a comma-delimited list of `key=value` nodel label pairs.
+For Kubernetes, the `region` attribute can be used to set the [`nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) field of the job specification. The value of `region` should be a comma-delimited list of `key=value` nodel label pairs.
 
 For example:
 ```tf

--- a/task/k8s/resources/resource_job.go
+++ b/task/k8s/resources/resource_job.go
@@ -36,6 +36,13 @@ func NewJob(client *client.Client, identifier common.Identifier, persistentVolum
 	j.Dependencies.PermissionSet = permissionSet
 	j.Attributes.Task = task
 	j.Attributes.Parallelism = task.Parallelism
+	j.Attributes.NodeSelector = map[string]string{}
+	for _, selector := range strings.Split(string(client.Cloud.Region), ",") {
+		key, value, is_found := strings.Cut(selector, "=")
+		if is_found && len(value) > 0 {
+			j.Attributes.NodeSelector[key] = value
+		}
+	}
 	return j
 }
 
@@ -43,11 +50,12 @@ type Job struct {
 	Client     *client.Client
 	Identifier string
 	Attributes struct {
-		Task        common.Task
-		Parallelism uint16
-		Addresses   []net.IP
-		Status      common.Status
-		Events      []common.Event
+		Task         common.Task
+		Parallelism  uint16
+		NodeSelector map[string]string
+		Addresses    []net.IP
+		Status       common.Status
+		Events       []common.Event
 	}
 	Dependencies struct {
 		*PersistentVolumeClaim
@@ -90,8 +98,12 @@ func (j *Job) Create(ctx context.Context) error {
 		return common.NotFoundError
 	}
 
-	// Define the accelerator settings (i.e. GPU type, model, ...)
 	jobNodeSelector := map[string]string{}
+	for selector, value := range j.Attributes.NodeSelector {
+		jobNodeSelector[selector] = value
+	}
+
+	// Define the accelerator settings (i.e. GPU type, model, ...)
 	jobAccelerator := match[3]
 	jobGPUType := "nvidia.com/gpu"
 	jobGPUCount := match[4]
@@ -108,7 +120,7 @@ func (j *Job) Create(ctx context.Context) error {
 	if jobGPUCount > "0" {
 		jobLimits[kubernetes_core.ResourceName(jobGPUType)] = kubernetes_resource.MustParse(jobGPUCount)
 		if jobAccelerator != "" {
-			jobNodeSelector = map[string]string{"accelerator": jobAccelerator}
+			jobNodeSelector["accelerator"] = jobAccelerator
 		}
 	}
 


### PR DESCRIPTION
* Adds the ability to use the `region` field of the task in the Terraform file to pass node selector labels to the job.
* Expected format is comma-delimited `key=value` pairs
   * e.g.  `region: foo=bar,goo=baz,...`
   * Hacky?