### PR TITLE
Automate AWS availability zone selection

### DIFF
--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -235,8 +235,8 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 				return err
 			}
 
-			if len(page.InstanceTypeOfferings) > 0 {
-				availabilityZone = aws.ToString(page.InstanceTypeOfferings[0].Location)
+			if offerings := page.InstanceTypeOfferings; len(offerings) > 0 {
+				availabilityZone = aws.ToString(offerings[0].Location)
 				break
 			}
 		}

--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -217,32 +217,31 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 		},
 	}
 
-	// Availability zone
-	if availabilityZone == "" {
-		offeringsInput := &ec2.DescribeInstanceTypeOfferingsInput{
-			LocationType: types.LocationTypeAvailabilityZone,
-			Filters: []types.Filter{
-				{
-					Name:   aws.String("instance-type"),
-					Values: []string{instanceType},
-				},
-			},
-		}
-
-		for offeringsPaginator := ec2.NewDescribeInstanceTypeOfferingsPaginator(svc, offeringsInput); offeringsPaginator.HasMorePages(); {
-			page, err := offeringsPaginator.NextPage(ctx)
-			if err != nil {
-				return err
-			}
-
-			if offerings := page.InstanceTypeOfferings; len(offerings) > 0 {
-				availabilityZone = aws.ToString(offerings[0].Location)
-				break
-			}
-		}
-	}
-
 	if subnetId == "" {
+		if availabilityZone == "" {
+			offeringsInput := &ec2.DescribeInstanceTypeOfferingsInput{
+				LocationType: types.LocationTypeAvailabilityZone,
+				Filters: []types.Filter{
+					{
+						Name:   aws.String("instance-type"),
+						Values: []string{instanceType},
+					},
+				},
+			}
+
+			for offeringsPaginator := ec2.NewDescribeInstanceTypeOfferingsPaginator(svc, offeringsInput); offeringsPaginator.HasMorePages(); {
+				page, err := offeringsPaginator.NextPage(ctx)
+				if err != nil {
+					return err
+				}
+
+				if offerings := page.InstanceTypeOfferings; len(offerings) > 0 {
+					availabilityZone = aws.ToString(offerings[0].Location)
+					break
+				}
+			}
+		}
+
 		// use availability zone
 		subnetOptions.Filters = append(subnetOptions.Filters, types.Filter{
 			Name:   aws.String("availability-zone"),


### PR DESCRIPTION
Closes #668, tested with this minimal example:

```hcl
terraform {
  required_providers {
    iterative = {
      source = "github.com/iterative/iterative"
    }
  }
}

provider "iterative" {}

resource "iterative_machine" "example" {
  cloud         = "aws"
  region        = "eu-central-1"
  instance_type = "g4dn.2xlarge"
}
``` 