### PR TITLE
Mechanical cleanups and style fixes

### DIFF
--- a/task/aws/client/client.go
+++ b/task/aws/client/client.go
@@ -34,13 +34,12 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 		return nil, err
 	}
 
-	c := new(Client)
-	c.Cloud = cloud
-	c.Region = region
-	c.Tags = cloud.Tags
-
-	c.Config = config
-
+	c := &Client{
+		Cloud:  cloud,
+		Region: region,
+		Tags:   cloud.Tags,
+		Config: config,
+	}
 	c.Services.EC2 = ec2.NewFromConfig(config)
 	c.Services.S3 = s3.NewFromConfig(config)
 	c.Services.STS = sts.NewFromConfig(config)

--- a/task/aws/resources/data_source_credentials.go
+++ b/task/aws/resources/data_source_credentials.go
@@ -9,31 +9,32 @@ import (
 )
 
 func NewCredentials(client *client.Client, identifier common.Identifier, bucket *Bucket) *Credentials {
-	c := new(Credentials)
-	c.Client = client
-	c.Identifier = identifier.Long()
+	c := &Credentials{
+		client:     client,
+		Identifier: identifier.Long(),
+	}
 	c.Dependencies.Bucket = bucket
 	return c
 }
 
 type Credentials struct {
-	Client       *client.Client
+	client       *client.Client
 	Identifier   string
 	Dependencies struct {
-		*Bucket
+		Bucket *Bucket
 	}
 	Resource map[string]string
 }
 
 func (c *Credentials) Read(ctx context.Context) error {
-	credentials, err := c.Client.Config.Credentials.Retrieve(ctx)
+	credentials, err := c.client.Config.Credentials.Retrieve(ctx)
 	if err != nil {
 		return err
 	}
 
 	connectionString := fmt.Sprintf(
 		":s3,provider=AWS,region=%s,access_key_id=%s,secret_access_key=%s,session_token=%s:%s",
-		c.Client.Region,
+		c.client.Region,
 		credentials.AccessKeyID,
 		credentials.SecretAccessKey,
 		credentials.SessionToken,
@@ -45,8 +46,8 @@ func (c *Credentials) Read(ctx context.Context) error {
 		"AWS_SECRET_ACCESS_KEY":   credentials.SecretAccessKey,
 		"AWS_SESSION_TOKEN":       credentials.SessionToken,
 		"RCLONE_REMOTE":           connectionString,
-		"TPI_TASK_CLOUD_PROVIDER": string(c.Client.Cloud.Provider),
-		"TPI_TASK_CLOUD_REGION":   c.Client.Region,
+		"TPI_TASK_CLOUD_PROVIDER": string(c.client.Cloud.Provider),
+		"TPI_TASK_CLOUD_REGION":   c.client.Region,
 		"TPI_TASK_IDENTIFIER":     c.Identifier,
 	}
 

--- a/task/aws/resources/data_source_default_vpc.go
+++ b/task/aws/resources/data_source_default_vpc.go
@@ -12,13 +12,11 @@ import (
 )
 
 func NewDefaultVPC(client *client.Client) *DefaultVPC {
-	d := new(DefaultVPC)
-	d.Client = client
-	return d
+	return &DefaultVPC{client: client}
 }
 
 type DefaultVPC struct {
-	Client   *client.Client
+	client   *client.Client
 	Resource *types.Vpc
 }
 
@@ -32,7 +30,7 @@ func (d *DefaultVPC) Read(ctx context.Context) error {
 		},
 	}
 
-	vpcs, err := d.Client.Services.EC2.DescribeVpcs(ctx, &input)
+	vpcs, err := d.client.Services.EC2.DescribeVpcs(ctx, &input)
 	if err != nil {
 		return err
 	}

--- a/task/aws/resources/data_source_default_vpc_subnets.go
+++ b/task/aws/resources/data_source_default_vpc_subnets.go
@@ -12,17 +12,18 @@ import (
 )
 
 func NewDefaultVPCSubnets(client *client.Client, defaultVpc *DefaultVPC) *DefaultVPCSubnets {
-	d := new(DefaultVPCSubnets)
-	d.Client = client
+	d := &DefaultVPCSubnets{
+		client: client,
+	}
 	d.Dependencies.DefaultVPC = defaultVpc
 	return d
 }
 
 type DefaultVPCSubnets struct {
-	Client       *client.Client
+	client       *client.Client
 	Resource     []*types.Subnet
 	Dependencies struct {
-		*DefaultVPC
+		DefaultVPC *DefaultVPC
 	}
 }
 
@@ -40,7 +41,7 @@ func (d *DefaultVPCSubnets) Read(ctx context.Context) error {
 		},
 	}
 
-	subnets, err := d.Client.Services.EC2.DescribeSubnets(ctx, &input)
+	subnets, err := d.client.Services.EC2.DescribeSubnets(ctx, &input)
 	if err != nil {
 		return err
 	}

--- a/task/aws/resources/data_source_image.go
+++ b/task/aws/resources/data_source_image.go
@@ -15,14 +15,14 @@ import (
 )
 
 func NewImage(client *client.Client, identifier string) *Image {
-	i := new(Image)
-	i.Client = client
-	i.Identifier = identifier
-	return i
+	return &Image{
+		client:     client,
+		Identifier: identifier,
+	}
 }
 
 type Image struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Attributes struct {
 		SSHUser string
@@ -73,7 +73,7 @@ func (i *Image) Read(ctx context.Context) error {
 		Filters: filters,
 	}
 
-	result, err := i.Client.Services.EC2.DescribeImages(ctx, &input)
+	result, err := i.client.Services.EC2.DescribeImages(ctx, &input)
 	if err != nil {
 		return err
 	}

--- a/task/aws/resources/data_source_permission_set.go
+++ b/task/aws/resources/data_source_permission_set.go
@@ -14,14 +14,14 @@ import (
 var validateARN = regexp.MustCompile(`arn:aws:iam::[\d]*:instance-profile/[\S]*`)
 
 func NewPermissionSet(client *client.Client, identifier string) *PermissionSet {
-	ps := new(PermissionSet)
-	ps.Client = client
-	ps.Identifier = identifier
-	return ps
+	return &PermissionSet{
+		client:     client,
+		Identifier: identifier,
+	}
 }
 
 type PermissionSet struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Resource   *types.LaunchTemplateIamInstanceProfileSpecificationRequest
 }

--- a/task/aws/resources/resource_key_pair.go
+++ b/task/aws/resources/resource_key_pair.go
@@ -17,21 +17,21 @@ import (
 )
 
 func NewKeyPair(client *client.Client, identifier common.Identifier) *KeyPair {
-	k := new(KeyPair)
-	k.Client = client
-	k.Identifier = identifier.Long()
-	return k
+	return &KeyPair{
+		client:     client,
+		Identifier: identifier.Long(),
+	}
 }
 
 type KeyPair struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Attributes ssh.DeterministicSSHKeyPair
 	Resource   *types.KeyPairInfo
 }
 
 func (k *KeyPair) Create(ctx context.Context) error {
-	keyPair, err := k.Client.GetKeyPair(ctx)
+	keyPair, err := k.client.GetKeyPair(ctx)
 	if err != nil {
 		return err
 	}
@@ -48,12 +48,12 @@ func (k *KeyPair) Create(ctx context.Context) error {
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: types.ResourceTypeKeyPair,
-				Tags:         makeTagSlice(k.Identifier, k.Client.Tags),
+				Tags:         makeTagSlice(k.Identifier, k.client.Tags),
 			},
 		},
 	}
 
-	pair, err := k.Client.Services.EC2.ImportKeyPair(ctx, &input)
+	pair, err := k.client.Services.EC2.ImportKeyPair(ctx, &input)
 	if err != nil {
 		var e smithy.APIError
 		if errors.As(err, &e) && e.ErrorCode() == "InvalidKeyPair.Duplicate" {
@@ -66,7 +66,7 @@ func (k *KeyPair) Create(ctx context.Context) error {
 		KeyPairIds: []string{aws.ToString(pair.KeyPairId)},
 	}
 
-	if err := ec2.NewKeyPairExistsWaiter(k.Client.Services.EC2).Wait(ctx, &waitInput, k.Client.Cloud.Timeouts.Create); err != nil {
+	if err := ec2.NewKeyPairExistsWaiter(k.client.Services.EC2).Wait(ctx, &waitInput, k.client.Cloud.Timeouts.Create); err != nil {
 		return err
 	}
 
@@ -74,7 +74,7 @@ func (k *KeyPair) Create(ctx context.Context) error {
 }
 
 func (k *KeyPair) Read(ctx context.Context) error {
-	pair, err := k.Client.GetKeyPair(ctx)
+	pair, err := k.client.GetKeyPair(ctx)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (k *KeyPair) Read(ctx context.Context) error {
 		KeyNames: []string{k.Identifier},
 	}
 
-	pairs, err := k.Client.Services.EC2.DescribeKeyPairs(ctx, &input)
+	pairs, err := k.client.Services.EC2.DescribeKeyPairs(ctx, &input)
 	if err != nil {
 		var e smithy.APIError
 		if errors.As(err, &e) && e.ErrorCode() == "InvalidKeyPair.NotFound" {
@@ -105,7 +105,7 @@ func (k *KeyPair) Delete(ctx context.Context) error {
 		KeyName: aws.String(k.Identifier),
 	}
 
-	if _, err := k.Client.Services.EC2.DeleteKeyPair(ctx, &input); err != nil {
+	if _, err := k.client.Services.EC2.DeleteKeyPair(ctx, &input); err != nil {
 		return err
 	}
 

--- a/task/az/client/client.go
+++ b/task/az/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
@@ -32,9 +33,10 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 
 	agent := "tpi"
 
-	c := new(Client)
-	c.Cloud = cloud
-	c.Settings = settings
+	c := &Client{
+		Cloud:    cloud,
+		Settings: settings,
+	}
 
 	for key, value := range tags {
 		c.Tags[key] = &value

--- a/task/az/resources/data_source_credentials.go
+++ b/task/az/resources/data_source_credentials.go
@@ -12,9 +12,10 @@ import (
 )
 
 func NewCredentials(client *client.Client, identifier common.Identifier, resourceGroup *ResourceGroup, storageAccount *StorageAccount, blobContainer *BlobContainer) *Credentials {
-	c := new(Credentials)
-	c.Client = client
-	c.Identifier = identifier.Long()
+	c := &Credentials{
+		client:     client,
+		Identifier: identifier.Long(),
+	}
 	c.Dependencies.ResourceGroup = resourceGroup
 	c.Dependencies.StorageAccount = storageAccount
 	c.Dependencies.BlobContainer = blobContainer
@@ -22,12 +23,12 @@ func NewCredentials(client *client.Client, identifier common.Identifier, resourc
 }
 
 type Credentials struct {
-	Client       *client.Client
+	client       *client.Client
 	Identifier   string
 	Dependencies struct {
-		*ResourceGroup
-		*StorageAccount
-		*BlobContainer
+		ResourceGroup  *ResourceGroup
+		StorageAccount *StorageAccount
+		BlobContainer  *BlobContainer
 	}
 	Resource map[string]string
 }
@@ -40,7 +41,7 @@ func (c *Credentials) Read(ctx context.Context) error {
 		c.Dependencies.BlobContainer.Identifier,
 	)
 
-	credentials, err := c.Client.Settings.GetClientCredentials()
+	credentials, err := c.client.Settings.GetClientCredentials()
 	if err != nil {
 		return err
 	}
@@ -49,7 +50,7 @@ func (c *Credentials) Read(ctx context.Context) error {
 		return errors.New("unable to find client secret")
 	}
 
-	subscriptionID := c.Client.Settings.GetSubscriptionID()
+	subscriptionID := c.client.Settings.GetSubscriptionID()
 
 	c.Resource = map[string]string{
 		"AZURE_CLIENT_ID":         credentials.ClientID,
@@ -57,8 +58,8 @@ func (c *Credentials) Read(ctx context.Context) error {
 		"AZURE_SUBSCRIPTION_ID":   subscriptionID,
 		"AZURE_TENANT_ID":         credentials.TenantID,
 		"RCLONE_REMOTE":           connectionString,
-		"TPI_TASK_CLOUD_PROVIDER": string(c.Client.Cloud.Provider),
-		"TPI_TASK_CLOUD_REGION":   c.Client.Region,
+		"TPI_TASK_CLOUD_PROVIDER": string(c.client.Cloud.Provider),
+		"TPI_TASK_CLOUD_REGION":   c.client.Region,
 		"TPI_TASK_IDENTIFIER":     c.Identifier,
 	}
 

--- a/task/az/resources/data_source_permission_set.go
+++ b/task/az/resources/data_source_permission_set.go
@@ -23,14 +23,14 @@ func ValidateARMID(id string) error {
 }
 
 func NewPermissionSet(client *client.Client, identifer string) *PermissionSet {
-	ps := new(PermissionSet)
-	ps.Client = client
-	ps.Identifier = identifer
-	return ps
+	return &PermissionSet{
+		client:     client,
+		Identifier: identifer,
+	}
 }
 
 type PermissionSet struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Resource   *compute.VirtualMachineScaleSetIdentity
 }

--- a/task/az/resources/resource_blob_container.go
+++ b/task/az/resources/resource_blob_container.go
@@ -11,26 +11,28 @@ import (
 )
 
 func NewBlobContainer(client *client.Client, identifier common.Identifier, resourceGroup *ResourceGroup, storageAccount *StorageAccount) *BlobContainer {
-	b := new(BlobContainer)
-	b.Client = client
-	b.Identifier = identifier.Short()
+	b := &BlobContainer{
+		client:     client,
+		Identifier: identifier.Short(),
+	}
+
 	b.Dependencies.ResourceGroup = resourceGroup
 	b.Dependencies.StorageAccount = storageAccount
 	return b
 }
 
 type BlobContainer struct {
-	Client       *client.Client
+	client       *client.Client
 	Identifier   string
 	Dependencies struct {
-		*ResourceGroup
-		*StorageAccount
+		ResourceGroup  *ResourceGroup
+		StorageAccount *StorageAccount
 	}
 	Resource *storage.BlobContainer
 }
 
 func (b *BlobContainer) Create(ctx context.Context) error {
-	container, err := b.Client.Services.BlobContainers.Create(
+	container, err := b.client.Services.BlobContainers.Create(
 		ctx,
 		b.Dependencies.ResourceGroup.Identifier,
 		b.Dependencies.StorageAccount.Identifier,
@@ -45,7 +47,7 @@ func (b *BlobContainer) Create(ctx context.Context) error {
 }
 
 func (b *BlobContainer) Read(ctx context.Context) error {
-	container, err := b.Client.Services.BlobContainers.Get(ctx, b.Dependencies.ResourceGroup.Identifier, b.Dependencies.StorageAccount.Identifier, b.Identifier)
+	container, err := b.client.Services.BlobContainers.Get(ctx, b.Dependencies.ResourceGroup.Identifier, b.Dependencies.StorageAccount.Identifier, b.Identifier)
 	if err != nil {
 		if err.(autorest.DetailedError).StatusCode == 404 {
 			return common.NotFoundError
@@ -62,7 +64,7 @@ func (b *BlobContainer) Update(ctx context.Context) error {
 }
 
 func (b *BlobContainer) Delete(ctx context.Context) error {
-	_, err := b.Client.Services.BlobContainers.Delete(ctx, b.Dependencies.ResourceGroup.Identifier, b.Dependencies.StorageAccount.Identifier, b.Identifier)
+	_, err := b.client.Services.BlobContainers.Delete(ctx, b.Dependencies.ResourceGroup.Identifier, b.Dependencies.StorageAccount.Identifier, b.Identifier)
 	if err != nil {
 		if err.(autorest.DetailedError).StatusCode == 404 {
 			return nil

--- a/task/az/resources/resource_group.go
+++ b/task/az/resources/resource_group.go
@@ -30,25 +30,25 @@ func ListResourceGroups(ctx context.Context, client *client.Client) ([]common.Id
 }
 
 func NewResourceGroup(client *client.Client, identifier common.Identifier) *ResourceGroup {
-	r := new(ResourceGroup)
-	r.Client = client
-	r.Identifier = identifier.Long()
-	return r
+	return &ResourceGroup{
+		client:     client,
+		Identifier: identifier.Long(),
+	}
 }
 
 type ResourceGroup struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Resource   *resources.Group
 }
 
 func (r *ResourceGroup) Create(ctx context.Context) error {
-	resourceGroup, err := r.Client.Services.Groups.CreateOrUpdate(
+	resourceGroup, err := r.client.Services.Groups.CreateOrUpdate(
 		ctx,
 		r.Identifier,
 		resources.Group{
-			Location: to.StringPtr(r.Client.Region),
-			Tags:     r.Client.Tags,
+			Location: to.StringPtr(r.client.Region),
+			Tags:     r.client.Tags,
 		})
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func (r *ResourceGroup) Create(ctx context.Context) error {
 }
 
 func (r *ResourceGroup) Read(ctx context.Context) error {
-	resourceGroup, err := r.Client.Services.Groups.Get(ctx, r.Identifier)
+	resourceGroup, err := r.client.Services.Groups.Get(ctx, r.Identifier)
 	if err != nil {
 		if err.(autorest.DetailedError).StatusCode == 404 {
 			return common.NotFoundError
@@ -76,7 +76,7 @@ func (r *ResourceGroup) Update(ctx context.Context) error {
 }
 
 func (r *ResourceGroup) Delete(ctx context.Context) error {
-	resourceGroupDeleteFuture, err := r.Client.Services.Groups.Delete(ctx, r.Identifier, "")
+	resourceGroupDeleteFuture, err := r.client.Services.Groups.Delete(ctx, r.Identifier, "")
 	if err != nil {
 		if err.(autorest.DetailedError).StatusCode == 404 {
 			return nil
@@ -84,7 +84,7 @@ func (r *ResourceGroup) Delete(ctx context.Context) error {
 		return err
 	}
 
-	err = resourceGroupDeleteFuture.WaitForCompletionRef(ctx, r.Client.Services.Groups.Client)
+	err = resourceGroupDeleteFuture.WaitForCompletionRef(ctx, r.client.Services.Groups.Client)
 	r.Resource = nil
 	return err
 }

--- a/task/common/cloud.go
+++ b/task/common/cloud.go
@@ -6,10 +6,10 @@ import (
 )
 
 type Cloud struct {
-	Timeouts
-	Provider
-	Region
-	Tags map[string]string
+	Timeouts Timeouts
+	Provider Provider
+	Region   Region
+	Tags     map[string]string
 }
 
 type Timeouts struct {

--- a/task/gcp/client/client.go
+++ b/task/gcp/client/client.go
@@ -51,11 +51,11 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 		region = val
 	}
 
-	c := new(Client)
-	c.Cloud = cloud
-	c.Region = region
-
-	c.Credentials = credentials
+	c := &Client{
+		Cloud:       cloud,
+		Region:      region,
+		Credentials: credentials,
+	}
 
 	computeService, err := compute.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {

--- a/task/gcp/resources/data_source_credentials.go
+++ b/task/gcp/resources/data_source_credentials.go
@@ -10,27 +10,28 @@ import (
 )
 
 func NewCredentials(client *client.Client, identifier common.Identifier, bucket *Bucket) *Credentials {
-	c := new(Credentials)
-	c.Client = client
-	c.Identifier = identifier.Long()
+	c := &Credentials{
+		client:     client,
+		Identifier: identifier.Long(),
+	}
 	c.Dependencies.Bucket = bucket
 	return c
 }
 
 type Credentials struct {
-	Client       *client.Client
+	client       *client.Client
 	Identifier   string
 	Dependencies struct {
-		*Bucket
+		Bucket *Bucket
 	}
 	Resource map[string]string
 }
 
 func (c *Credentials) Read(ctx context.Context) error {
-	if len(c.Client.Credentials.JSON) == 0 {
+	if len(c.client.Credentials.JSON) == 0 {
 		return errors.New("unable to find credentials JSON string")
 	}
-	credentials := string(c.Client.Credentials.JSON)
+	credentials := string(c.client.Credentials.JSON)
 
 	connectionString := fmt.Sprintf(
 		":googlecloudstorage,service_account_credentials='%s':%s",
@@ -41,8 +42,8 @@ func (c *Credentials) Read(ctx context.Context) error {
 	c.Resource = map[string]string{
 		"GOOGLE_APPLICATION_CREDENTIALS_DATA": credentials,
 		"RCLONE_REMOTE":                       connectionString,
-		"TPI_TASK_CLOUD_PROVIDER":             string(c.Client.Cloud.Provider),
-		"TPI_TASK_CLOUD_REGION":               c.Client.Region,
+		"TPI_TASK_CLOUD_PROVIDER":             string(c.client.Cloud.Provider),
+		"TPI_TASK_CLOUD_REGION":               c.client.Region,
 		"TPI_TASK_IDENTIFIER":                 c.Identifier,
 	}
 

--- a/task/gcp/resources/data_source_default_network.go
+++ b/task/gcp/resources/data_source_default_network.go
@@ -12,18 +12,18 @@ import (
 )
 
 func NewDefaultNetwork(client *client.Client) *DefaultNetwork {
-	d := new(DefaultNetwork)
-	d.Client = client
-	return d
+	return &DefaultNetwork{
+		client: client,
+	}
 }
 
 type DefaultNetwork struct {
-	Client   *client.Client
+	client   *client.Client
 	Resource *compute.Network
 }
 
 func (d *DefaultNetwork) Read(ctx context.Context) error {
-	network, err := d.Client.Services.Compute.Networks.Get(d.Client.Credentials.ProjectID, "default").Do()
+	network, err := d.client.Services.Compute.Networks.Get(d.client.Credentials.ProjectID, "default").Do()
 	if err != nil {
 		var e *googleapi.Error
 		if errors.As(err, &e) && e.Code == 404 {

--- a/task/gcp/resources/data_source_image.go
+++ b/task/gcp/resources/data_source_image.go
@@ -13,14 +13,14 @@ import (
 )
 
 func NewImage(client *client.Client, identifier string) *Image {
-	i := new(Image)
-	i.Client = client
-	i.Identifier = identifier
-	return i
+	return &Image{
+		client:     client,
+		Identifier: identifier,
+	}
 }
 
 type Image struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Attributes struct {
 		SSHUser string
@@ -47,11 +47,11 @@ func (i *Image) Read(ctx context.Context) error {
 	project := match[2]
 	imageOrFamily := match[3]
 
-	resource, err := i.Client.Services.Compute.Images.Get(project, imageOrFamily).Do()
+	resource, err := i.client.Services.Compute.Images.Get(project, imageOrFamily).Do()
 	if err != nil {
 		var e *googleapi.Error
 		if errors.As(err, &e) && e.Code == 404 {
-			resource, err := i.Client.Services.Compute.Images.GetFromFamily(project, imageOrFamily).Do()
+			resource, err := i.client.Services.Compute.Images.GetFromFamily(project, imageOrFamily).Do()
 			if err != nil {
 				var e *googleapi.Error
 				if errors.As(err, &e) && e.Code == 404 {

--- a/task/gcp/resources/data_source_permission_set.go
+++ b/task/gcp/resources/data_source_permission_set.go
@@ -53,14 +53,14 @@ func parseScopes(scopes []string) []string {
 }
 
 func NewPermissionSet(client *client.Client, identifier string) *PermissionSet {
-	ps := new(PermissionSet)
-	ps.Client = client
-	ps.Identifier = identifier
-	return ps
+	return &PermissionSet{
+		client:     client,
+		Identifier: identifier,
+	}
 }
 
 type PermissionSet struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Resource   []*compute.ServiceAccount
 }

--- a/task/k8s/client/client.go
+++ b/task/k8s/client/client.go
@@ -49,13 +49,14 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 		return nil, err
 	}
 
-	c := new(Client)
-	c.Cloud = cloud
-	c.Namespace = namespace
-	c.Tags = tags
-	c.Config = &config
-	c.ClientConfig = clientConfig
-	c.ClientSet = client
+	c := &Client{
+		Cloud:        cloud,
+		Namespace:    namespace,
+		Tags:         tags,
+		Config:       &config,
+		ClientConfig: clientConfig,
+		ClientSet:    client,
+	}
 	c.Services.Batch = client.BatchV1()
 	c.Services.Core = client.CoreV1()
 	return c, nil

--- a/task/k8s/resources/data_source_permission_set.go
+++ b/task/k8s/resources/data_source_permission_set.go
@@ -7,14 +7,14 @@ import (
 )
 
 func NewPermissionSet(client *client.Client, identifier string) *PermissionSet {
-	ps := new(PermissionSet)
-	ps.Client = client
-	ps.Identifier = identifier
-	return ps
+	return &PermissionSet{
+		client:     client,
+		Identifier: identifier,
+	}
 }
 
 type PermissionSet struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Resource   struct {
 		ServiceAccountName           string

--- a/task/k8s/resources/resource_job.go
+++ b/task/k8s/resources/resource_job.go
@@ -28,9 +28,10 @@ import (
 )
 
 func NewJob(client *client.Client, identifier common.Identifier, persistentVolumeClaim *PersistentVolumeClaim, configMap *ConfigMap, permissionSet *PermissionSet, task common.Task) *Job {
-	j := new(Job)
-	j.Client = client
-	j.Identifier = identifier.Long()
+	j := &Job{
+		client:     client,
+		Identifier: identifier.Long(),
+	}
 	j.Dependencies.PersistentVolumeClaim = persistentVolumeClaim
 	j.Dependencies.ConfigMap = configMap
 	j.Dependencies.PermissionSet = permissionSet
@@ -47,7 +48,7 @@ func NewJob(client *client.Client, identifier common.Identifier, persistentVolum
 }
 
 type Job struct {
-	Client     *client.Client
+	client     *client.Client
 	Identifier string
 	Attributes struct {
 		Task         common.Task
@@ -58,9 +59,9 @@ type Job struct {
 		Events       []common.Event
 	}
 	Dependencies struct {
-		*PersistentVolumeClaim
-		*ConfigMap
-		*PermissionSet
+		PersistentVolumeClaim *PersistentVolumeClaim
+		ConfigMap             *ConfigMap
+		PermissionSet         *PermissionSet
 	}
 	Resource *kubernetes_batch.Job
 }
@@ -214,9 +215,9 @@ func (j *Job) Create(ctx context.Context) error {
 	job := kubernetes_batch.Job{
 		ObjectMeta: kubernetes_meta.ObjectMeta{
 			Name:        j.Identifier,
-			Namespace:   j.Client.Namespace,
-			Labels:      j.Client.Tags,
-			Annotations: j.Client.Tags,
+			Namespace:   j.client.Namespace,
+			Labels:      j.client.Tags,
+			Annotations: j.client.Tags,
 		},
 		Spec: kubernetes_batch.JobSpec{
 			ActiveDeadlineSeconds: &jobActiveDeadlineSeconds,
@@ -263,7 +264,7 @@ func (j *Job) Create(ctx context.Context) error {
 	}
 
 	// Ask Kubernetes to create the job.
-	out, err := j.Client.Services.Batch.Jobs(j.Client.Namespace).Create(ctx, &job, kubernetes_meta.CreateOptions{})
+	out, err := j.client.Services.Batch.Jobs(j.client.Namespace).Create(ctx, &job, kubernetes_meta.CreateOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*kubernetes_errors.StatusError); ok && statusErr.ErrStatus.Code == 409 {
 			return j.Read(ctx)
@@ -276,7 +277,7 @@ func (j *Job) Create(ctx context.Context) error {
 }
 
 func (j *Job) Read(ctx context.Context) error {
-	job, err := j.Client.Services.Batch.Jobs(j.Client.Namespace).Get(ctx, j.Identifier, kubernetes_meta.GetOptions{})
+	job, err := j.client.Services.Batch.Jobs(j.client.Namespace).Get(ctx, j.Identifier, kubernetes_meta.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*kubernetes_errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return common.NotFoundError
@@ -284,7 +285,7 @@ func (j *Job) Read(ctx context.Context) error {
 		return err
 	}
 	eventListOptions := kubernetes_meta.ListOptions{FieldSelector: fields.OneTermEqualSelector("involvedObject.name", job.Name).String()}
-	events, err := j.Client.Services.Core.Events(j.Client.Namespace).List(ctx, eventListOptions)
+	events, err := j.client.Services.Core.Events(j.client.Namespace).List(ctx, eventListOptions)
 	if err != nil {
 		return err
 	}
@@ -308,7 +309,7 @@ func (j *Job) Read(ctx context.Context) error {
 }
 
 func (j *Job) Delete(ctx context.Context) error {
-	_, err := j.Client.Services.Batch.Jobs(j.Client.Namespace).Get(ctx, j.Identifier, kubernetes_meta.GetOptions{})
+	_, err := j.client.Services.Batch.Jobs(j.client.Namespace).Get(ctx, j.Identifier, kubernetes_meta.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*kubernetes_errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return nil
@@ -321,15 +322,15 @@ func (j *Job) Delete(ctx context.Context) error {
 	// ownerReference.blockOwnerDeletion=true.
 	propagationPolicy := kubernetes_meta.DeletePropagationForeground
 
-	err = j.Client.Services.Batch.Jobs(j.Client.Namespace).Delete(ctx, j.Identifier, kubernetes_meta.DeleteOptions{
+	err = j.client.Services.Batch.Jobs(j.client.Namespace).Delete(ctx, j.Identifier, kubernetes_meta.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	})
 	if err != nil {
 		return fmt.Errorf("Failed to delete Job! API error: %s", err)
 	}
 
-	err = terraform_resource.RetryContext(ctx, j.Client.Cloud.Timeouts.Delete, func() *terraform_resource.RetryError {
-		_, err := j.Client.Services.Batch.Jobs(j.Client.Namespace).Get(ctx, j.Identifier, kubernetes_meta.GetOptions{})
+	err = terraform_resource.RetryContext(ctx, j.client.Cloud.Timeouts.Delete, func() *terraform_resource.RetryError {
+		_, err := j.client.Services.Batch.Jobs(j.client.Namespace).Get(ctx, j.Identifier, kubernetes_meta.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*kubernetes_errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 				return nil
@@ -348,7 +349,7 @@ func (j *Job) Delete(ctx context.Context) error {
 }
 
 func (j *Job) Logs(ctx context.Context) ([]string, error) {
-	pods, err := j.Client.Services.Core.Pods(j.Client.Namespace).List(ctx, kubernetes_meta.ListOptions{
+	pods, err := j.client.Services.Core.Pods(j.client.Namespace).List(ctx, kubernetes_meta.ListOptions{
 		LabelSelector: fmt.Sprintf("controller-uid=%s", j.Resource.Spec.Selector.MatchLabels["controller-uid"]),
 	})
 	if err != nil {
@@ -358,7 +359,7 @@ func (j *Job) Logs(ctx context.Context) ([]string, error) {
 	var result []string
 
 	for _, pod := range pods.Items {
-		logs, err := j.Client.Services.Core.Pods(j.Client.Namespace).GetLogs(pod.Name, &kubernetes_core.PodLogOptions{
+		logs, err := j.client.Services.Core.Pods(j.client.Namespace).GetLogs(pod.Name, &kubernetes_core.PodLogOptions{
 			Timestamps: true,
 		}).Stream(ctx)
 		if err != nil {


### PR DESCRIPTION
Do not use anonymous struct members.
Make client a private member.
Use literals instead of `new(type)` where possible.