### PR TITLE
Upgrade `az` to the new `sdk/resourcemanager`

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -64,6 +64,8 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - run: go test ./task -v -timeout=30m -count=1 -tags=smoke
+      env:
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - if: always()
       uses: actions/checkout@v3
       with:
@@ -71,6 +73,7 @@ jobs:
     - if: always()
       run: go test ./task -v -timeout=30m -count=1 -tags=smoke
       env:
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         SMOKE_TEST_SWEEP: true
   test-k8s:
     name: test (K8S)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,12 @@ go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go v58.1.0+incompatible
-	github.com/Azure/go-autorest/autorest v0.11.18
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.1.3
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.1.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
@@ -36,7 +41,7 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
 	github.com/wessie/appdirs v0.0.0-20141031215813-6573e894f8e2
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 	google.golang.org/api v0.96.0
 	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61
@@ -53,15 +58,18 @@ require (
 	cloud.google.com/go/iam v0.4.0 // indirect
 	cloud.google.com/go/storage v1.26.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1 // indirect
 	github.com/Azure/azure-storage-blob-go v0.14.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.14 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
@@ -103,9 +111,9 @@ require (
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -140,6 +148,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jzelinskie/whirlpool v0.0.0-20201016144138-0675e54bb004 // indirect
 	github.com/klauspost/compress v1.15.10 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
@@ -164,6 +173,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.0-beta.8 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
@@ -188,9 +198,9 @@ require (
 	github.com/zclconf/go-cty v1.8.4 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 // indirect
+	golang.org/x/net v0.0.0-20220926192436-02166a98028e // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
-	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
+	golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ cloud.google.com/go v0.93.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+Y
 cloud.google.com/go v0.94.1/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW4=
 cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Udc=
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
-cloud.google.com/go v0.100.2 h1:t9Iw5QH5v4XtlEQaCtUY7x6sCABps8sW0acw7e2WQ6Y=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
 cloud.google.com/go v0.104.0 h1:gSmWO7DY1vOm0MVU6DNXM11BWHHsTUmsC5cv1fuW5X8=
@@ -45,7 +44,6 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/compute v0.1.0/go.mod h1:GAesmwr110a34z04OlxYkATPBEfVhkymfTBXtfbBFow=
 cloud.google.com/go/compute v1.3.0/go.mod h1:cCZiE1NHEtai4wiufUhW8I8S1JKkAnhnQJWM7YD99wM=
-cloud.google.com/go/compute v1.5.0 h1:b1zWmYuuHz7gO9kDcM/EpHGr06UgsYNRpNJzI2kFiLM=
 cloud.google.com/go/compute v1.5.0/go.mod h1:9SMHyhJlzhlkJqrPAc839t2BZFTSk6Jdj6mkzQJeu0M=
 cloud.google.com/go/compute v1.6.0/go.mod h1:T29tfhtVbq1wvAPo0E3+7vhgmkOYeXjhFvz/FMzPu0s=
 cloud.google.com/go/compute v1.6.1/go.mod h1:g85FgpzFvNULZ+S8AYq87axRKuf2Kh7deLqV/jJ3thU=
@@ -55,7 +53,6 @@ cloud.google.com/go/compute v1.10.0/go.mod h1:ER5CLbMxl90o2jtNbGSbtfOpQKR0t15FOt
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
-cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
 cloud.google.com/go/iam v0.4.0 h1:YBYU00SCDzZJdHqVc4I5d6lsklcYIjQZa1YmEz4jlSE=
 cloud.google.com/go/iam v0.4.0/go.mod h1:cbaZxyScUhxl7ZAkNWiALgihfP75wS/fUsVNaa1r3vA=
@@ -68,7 +65,6 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-cloud.google.com/go/storage v1.14.0 h1:6RRlFMv1omScs6iq2hfE3IvgE+l6RfJPampq8UZc5TU=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 cloud.google.com/go/storage v1.26.0 h1:lYAGjknyDJirSzfwUlkv4Nsnj7od7foxQNH/fqZqles=
@@ -83,6 +79,21 @@ github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVt
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go v58.1.0+incompatible h1:WFsr3Efy7uweykOAEfOHO3ACtuwIv+rrFmSn9K48VnA=
 github.com/Azure/azure-sdk-for-go v58.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.1.3 h1:8LoU8N2lIUzkmstvwXvVfniMZlFbesfT2AmA1aqvRr8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.1.3/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0 h1:QkAcEIAKbNL4KoFr4SathZPhDhF4mVwpBMFlYjyAqy8=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0/go.mod h1:bhXu1AjYL+wutSL/kpSq6s7733q2Rb0yuot9Zgfqa/0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1 h1:XUNQ4mw+zJmaA2KXzP9JlQiecy1SI+Eog7xVkPiqIbg=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0 h1:/Di3vB4sNeQ+7A8efjUVENvyB945Wruvstucqp7ZArg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0/go.mod h1:gM3K25LQlsET3QR+4V74zxCsFAy0r6xMNN9n80SZn+4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0 h1:lMW1lD/17LUA5z1XTURo7LcVG2ICBPlyMHjIUrcFZNQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0/go.mod h1:s1tW/At+xHqjNFvWU4G0c0Qv33KOhvbGNj0RCTQDV8s=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.1.0 h1:fsVypuWj+j1xqp8S7t5SyibKxVt5OyjVUHO5rlLkZnw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.1.0/go.mod h1:c+Lifp3EDEamAkPVzMooRNOK6CZjNSdEnf1A7jsI9u4=
 github.com/Azure/azure-storage-blob-go v0.14.0 h1:1BCg74AmVdYwO3dlKwtFU1V0wU2PZdREkXvAmZJRUlM=
 github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -117,6 +128,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 h1:VgSJlZH5u0k2qxSpqyghcFQKmvYckj46uymKK5XzkBM=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Julusian/godocdown v0.0.0-20170816220326-6d19f8ff2df8/go.mod h1:INZr5t32rG59/5xeltqoCJoNY7e5x/3xoY9WSWVWg74=
@@ -192,7 +205,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.40.27 h1:8fWW0CpmBZ8WWduNwl4vE9t07nMYFrhAsUHjPj81qUM=
 github.com/aws/aws-sdk-go v1.40.27/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.44.102 h1:6tUCTGL2UDbFZae1TLGk8vTgeXuzkb8KbAe2FiAeKHc=
 github.com/aws/aws-sdk-go v1.44.102/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
@@ -323,6 +335,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -428,6 +441,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -465,10 +480,7 @@ github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
-github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -488,7 +500,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -542,7 +553,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
-github.com/googleapis/gax-go/v2 v2.3.0 h1:nRJtk3y8Fm770D42QV6T90ZnvFZyk7agSo3Q+Z9p3WI=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/gax-go/v2 v2.5.1 h1:kBRZU0PSuI7PspsSb/ChWoVResUcwNVIdpB049pKTiw=
@@ -581,8 +591,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 h1:1/D3zfFHttUKaCaGKZ/dR2roBXv0vKbSCnssIldfQdI=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
-github.com/hashicorp/go-getter v1.5.11 h1:wioTuNmaBU3IE9vdFtFMcmZWj0QzLc6DYaP6sNe5onY=
-github.com/hashicorp/go-getter v1.5.11/go.mod h1:9i48BP6wpWweI/0/+FBjqLrp9S8XtwUGjiu0QkWHEaY=
 github.com/hashicorp/go-getter v1.6.2 h1:7jX7xcB+uVCliddZgeKyNxv0xoT7qL5KDtH7rU4IqIk=
 github.com/hashicorp/go-getter v1.6.2/go.mod h1:IZCrswsZPeWv9IkVnLElzRU/gz/QPi6pZHn4tv6vbwA=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
@@ -607,7 +615,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -704,7 +711,6 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.13.4 h1:0zhec2I8zGnjWcKyLl6i3gPqKANCCn5e9xmviEEeX6s=
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.15.10 h1:Ai8UzuomSCDw90e1qNMtb15msBXsNpH6gzkkENQNcJo=
 github.com/klauspost/compress v1.15.10/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
@@ -790,7 +796,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
-github.com/mitchellh/go-testing-interface v1.0.4 h1:ZU1VNC02qyufSZsjjs7+khruk2fKvbQ3TwRV/IBCeFA=
 github.com/mitchellh/go-testing-interface v1.0.4/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
@@ -876,6 +881,8 @@ github.com/pengsrc/go-shared v0.2.1-0.20190131101655-1999055a4a14/go.mod h1:jVbl
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -1048,7 +1055,6 @@ github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcy
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
-github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
@@ -1169,8 +1175,8 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
-golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
+golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1270,14 +1276,13 @@ golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
-golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 h1:asZqf0wXastQr+DudYagQS8uBO8bHKeYD1vbAvGmFL8=
-golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220926192436-02166a98028e h1:I51lVG9ykW5AQeTE50sJ0+gJCAF0J78Hf1+1VUCGxDI=
+golang.org/x/net v0.0.0-20220926192436-02166a98028e/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1299,7 +1304,6 @@ golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
@@ -1316,7 +1320,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1401,6 +1404,7 @@ golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1416,7 +1420,6 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1424,8 +1427,8 @@ golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 h1:nwzwVf0l2Y/lkov/+IYgMMbFyI+QypZDds9RxlSmsFQ=
+golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1517,7 +1520,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f h1:GGU+dLjvlC3qDwqYgL6UgRmHXhOOgns0bZu2Ty5mm6U=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -1561,7 +1563,6 @@ google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tD
 google.golang.org/api v0.67.0/go.mod h1:ShHKP8E60yPsKNw/w8w+VYaj9H6buA5UqDp8dhbQZ6g=
 google.golang.org/api v0.70.0/go.mod h1:Bs4ZM2HGifEvXwd50TtW70ovgJffJYw2oRCOFU/SkfA=
 google.golang.org/api v0.71.0/go.mod h1:4PyU6e6JogV1f9eA4voyrTY2batOLdgZ5qZ5HOCc4j8=
-google.golang.org/api v0.74.0 h1:ExR2D+5TYIrMphWgs5JCgwRhEDlPDXXrLwHHMgPHTXE=
 google.golang.org/api v0.74.0/go.mod h1:ZpfMZOVRMywNyvJFeqL9HRWBgAuRfSjJFpe9QtRRyDs=
 google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69ljA=
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
@@ -1657,7 +1658,6 @@ google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf/go.mod h1:kGP+zUP2
 google.golang.org/genproto v0.0.0-20220304144024-325a89244dc8/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/genproto v0.0.0-20220310185008-1973136f34c6/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/genproto v0.0.0-20220324131243-acbaeb5b85eb/go.mod h1:hAL49I2IFola2sVEjAn7MEwsja0xp51I0tlGAf9hz4E=
-google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac h1:qSNTkEN+L2mvWcLgJOR+8bdHX9rN/IdU3A1Ghpfb1Rg=
 google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220413183235-5e96e2839df9/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
@@ -1704,7 +1704,6 @@ google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.45.0 h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
@@ -1725,7 +1724,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/task/az/client/client.go
+++ b/task/az/client/client.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-04-01/storage"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 
 	"terraform-provider-iterative/task/common"
@@ -26,12 +27,10 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 		return nil, errors.New("subscription environment variable not found")
 	}
 
-	authorizer, err := settings.GetAuthorizer()
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
-
-	agent := "tpi"
 
 	c := &Client{
 		Cloud:    cloud,
@@ -56,75 +55,68 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 
 	c.Region = region
 
-	c.Services.Groups = resources.NewGroupsClient(subscription)
-	c.Services.Groups.Authorizer = authorizer
-	if err := c.Services.Groups.AddToUserAgent(agent); err != nil {
+	c.Services.ResourceGroups, err = armresources.NewResourceGroupsClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.SecurityGroups = network.NewSecurityGroupsClient(subscription)
-	c.Services.SecurityGroups.Authorizer = authorizer
-	if err := c.Services.SecurityGroups.AddToUserAgent(agent); err != nil {
+	c.Services.SecurityGroups, err = armnetwork.NewSecurityGroupsClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.PublicIPPrefixes = network.NewPublicIPPrefixesClient(subscription)
-	c.Services.PublicIPPrefixes.Authorizer = authorizer
-	if err := c.Services.PublicIPPrefixes.AddToUserAgent(agent); err != nil {
+	c.Services.PublicIPPrefixes, err = armnetwork.NewPublicIPPrefixesClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.PublicIPAddresses = network.NewPublicIPAddressesClient(subscription)
-	c.Services.PublicIPAddresses.Authorizer = authorizer
-	if err := c.Services.PublicIPAddresses.AddToUserAgent(agent); err != nil {
+	c.Services.PublicIPAddresses, err = armnetwork.NewPublicIPAddressesClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualNetworks = network.NewVirtualNetworksClient(subscription)
-	c.Services.VirtualNetworks.Authorizer = authorizer
-	if err := c.Services.VirtualNetworks.AddToUserAgent(agent); err != nil {
+	c.Services.VirtualNetworks, err = armnetwork.NewVirtualNetworksClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.Subnets = network.NewSubnetsClient(subscription)
-	c.Services.Subnets.Authorizer = authorizer
-	if err := c.Services.Subnets.AddToUserAgent(agent); err != nil {
+	c.Services.Subnets, err = armnetwork.NewSubnetsClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.Interfaces = network.NewInterfacesClient(subscription)
-	c.Services.Interfaces.Authorizer = authorizer
-	if err := c.Services.Interfaces.AddToUserAgent(agent); err != nil {
+	c.Services.Interfaces, err = armnetwork.NewInterfacesClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachines = compute.NewVirtualMachinesClient(subscription)
-	c.Services.VirtualMachines.Authorizer = authorizer
-	if err := c.Services.VirtualMachines.AddToUserAgent(agent); err != nil {
+	c.Services.VirtualMachines, err = armcompute.NewVirtualMachinesClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachineScaleSets = compute.NewVirtualMachineScaleSetsClient(subscription)
-	c.Services.VirtualMachineScaleSets.Authorizer = authorizer
-	if err := c.Services.VirtualMachineScaleSets.AddToUserAgent(agent); err != nil {
+	c.Services.VirtualMachineScaleSets, err = armcompute.NewVirtualMachineScaleSetsClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachineScaleSetVMs = compute.NewVirtualMachineScaleSetVMsClient(subscription)
-	c.Services.VirtualMachineScaleSetVMs.Authorizer = authorizer
-	if err := c.Services.VirtualMachineScaleSetVMs.AddToUserAgent(agent); err != nil {
+	c.Services.VirtualMachineScaleSetVMs, err = armcompute.NewVirtualMachineScaleSetVMsClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.StorageAccounts = storage.NewAccountsClient(subscription)
-	c.Services.StorageAccounts.Authorizer = authorizer
-	if err := c.Services.StorageAccounts.AddToUserAgent(agent); err != nil {
+	c.Services.VirtualMachineScaleSets, err = armcompute.NewVirtualMachineScaleSetsClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
-	c.Services.BlobContainers = storage.NewBlobContainersClient(subscription)
-	c.Services.BlobContainers.Authorizer = authorizer
-	if err := c.Services.BlobContainers.AddToUserAgent(agent); err != nil {
+	c.Services.StorageAccounts, err = armstorage.NewAccountsClient(subscription, cred, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Services.BlobContainers, err = armstorage.NewBlobContainersClient(subscription, cred, nil)
+	if err != nil {
 		return nil, err
 	}
 
@@ -137,21 +129,22 @@ type Client struct {
 	Tags     map[string]*string
 	Settings auth.EnvironmentSettings
 	Services struct {
-		Groups                    resources.GroupsClient
-		SecurityGroups            network.SecurityGroupsClient
-		PublicIPPrefixes          network.PublicIPPrefixesClient
-		PublicIPAddresses         network.PublicIPAddressesClient
-		VirtualNetworks           network.VirtualNetworksClient
-		Subnets                   network.SubnetsClient
-		Interfaces                network.InterfacesClient
-		VirtualMachines           compute.VirtualMachinesClient
-		VirtualMachineScaleSets   compute.VirtualMachineScaleSetsClient
-		VirtualMachineScaleSetVMs compute.VirtualMachineScaleSetVMsClient
-		StorageAccounts           storage.AccountsClient
-		BlobContainers            storage.BlobContainersClient
+		ResourceGroups            *armresources.ResourceGroupsClient
+		SecurityGroups            *armnetwork.SecurityGroupsClient
+		PublicIPPrefixes          *armnetwork.PublicIPPrefixesClient
+		PublicIPAddresses         *armnetwork.PublicIPAddressesClient
+		VirtualNetworks           *armnetwork.VirtualNetworksClient
+		Subnets                   *armnetwork.SubnetsClient
+		Interfaces                *armnetwork.InterfacesClient
+		VirtualMachines           *armcompute.VirtualMachinesClient
+		VirtualMachineScaleSets   *armcompute.VirtualMachineScaleSetsClient
+		VirtualMachineScaleSetVMs *armcompute.VirtualMachineScaleSetVMsClient
+		StorageAccounts           *armstorage.AccountsClient
+		BlobContainers            *armstorage.BlobContainersClient
 	}
 }
 
+// FIXME: this function is broken with the new credential source
 func (c *Client) GetKeyPair(ctx context.Context) (*ssh.DeterministicSSHKeyPair, error) {
 	credentials, err := c.Settings.GetClientCredentials()
 	if err != nil {

--- a/task/az/client/client.go
+++ b/task/az/client/client.go
@@ -27,7 +27,7 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 		return nil, errors.New("subscription environment variable not found")
 	}
 
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	credential, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,67 +55,67 @@ func New(ctx context.Context, cloud common.Cloud, tags map[string]string) (*Clie
 
 	c.Region = region
 
-	c.Services.ResourceGroups, err = armresources.NewResourceGroupsClient(subscription, cred, nil)
+	c.Services.ResourceGroups, err = armresources.NewResourceGroupsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.SecurityGroups, err = armnetwork.NewSecurityGroupsClient(subscription, cred, nil)
+	c.Services.SecurityGroups, err = armnetwork.NewSecurityGroupsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.PublicIPPrefixes, err = armnetwork.NewPublicIPPrefixesClient(subscription, cred, nil)
+	c.Services.PublicIPPrefixes, err = armnetwork.NewPublicIPPrefixesClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.PublicIPAddresses, err = armnetwork.NewPublicIPAddressesClient(subscription, cred, nil)
+	c.Services.PublicIPAddresses, err = armnetwork.NewPublicIPAddressesClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualNetworks, err = armnetwork.NewVirtualNetworksClient(subscription, cred, nil)
+	c.Services.VirtualNetworks, err = armnetwork.NewVirtualNetworksClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.Subnets, err = armnetwork.NewSubnetsClient(subscription, cred, nil)
+	c.Services.Subnets, err = armnetwork.NewSubnetsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.Interfaces, err = armnetwork.NewInterfacesClient(subscription, cred, nil)
+	c.Services.Interfaces, err = armnetwork.NewInterfacesClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachines, err = armcompute.NewVirtualMachinesClient(subscription, cred, nil)
+	c.Services.VirtualMachines, err = armcompute.NewVirtualMachinesClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachineScaleSets, err = armcompute.NewVirtualMachineScaleSetsClient(subscription, cred, nil)
+	c.Services.VirtualMachineScaleSets, err = armcompute.NewVirtualMachineScaleSetsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachineScaleSetVMs, err = armcompute.NewVirtualMachineScaleSetVMsClient(subscription, cred, nil)
+	c.Services.VirtualMachineScaleSetVMs, err = armcompute.NewVirtualMachineScaleSetVMsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.VirtualMachineScaleSets, err = armcompute.NewVirtualMachineScaleSetsClient(subscription, cred, nil)
+	c.Services.VirtualMachineScaleSets, err = armcompute.NewVirtualMachineScaleSetsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.StorageAccounts, err = armstorage.NewAccountsClient(subscription, cred, nil)
+	c.Services.StorageAccounts, err = armstorage.NewAccountsClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Services.BlobContainers, err = armstorage.NewBlobContainersClient(subscription, cred, nil)
+	c.Services.BlobContainers, err = armstorage.NewBlobContainersClient(subscription, credential, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/task/az/resources/data_source_credentials.go
+++ b/task/az/resources/data_source_credentials.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"terraform-provider-iterative/task/az/client"
 	"terraform-provider-iterative/task/common"
 )
@@ -37,7 +35,7 @@ func (c *Credentials) Read(ctx context.Context) error {
 	connectionString := fmt.Sprintf(
 		":azureblob,account='%s',key='%s':%s",
 		c.Dependencies.StorageAccount.Identifier,
-		to.String(c.Dependencies.StorageAccount.Attributes.Value),
+		*c.Dependencies.StorageAccount.Attributes.Value,
 		c.Dependencies.BlobContainer.Identifier,
 	)
 

--- a/task/az/resources/data_source_permission_set.go
+++ b/task/az/resources/data_source_permission_set.go
@@ -6,7 +6,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 
 	"terraform-provider-iterative/task/az/client"
 )
@@ -32,12 +33,12 @@ func NewPermissionSet(client *client.Client, identifer string) *PermissionSet {
 type PermissionSet struct {
 	client     *client.Client
 	Identifier string
-	Resource   *compute.VirtualMachineScaleSetIdentity
+	Resource   *armcompute.VirtualMachineScaleSetIdentity
 }
 
 func (ps *PermissionSet) Read(ctx context.Context) error {
 	identities := strings.Split(ps.Identifier, ",")
-	identityMap := map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
+	identityMap := map[string]*armcompute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
 	for _, identity := range identities {
 		identity = strings.TrimSpace(identity)
 		if identity == "" {
@@ -47,15 +48,15 @@ func (ps *PermissionSet) Read(ctx context.Context) error {
 			return err
 		}
 
-		identityMap[identity] = &compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
+		identityMap[identity] = &armcompute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
 	}
 	if len(identityMap) == 0 {
 		ps.Resource = nil
 		return nil
 	}
-	ps.Resource = &compute.VirtualMachineScaleSetIdentity{
+	ps.Resource = &armcompute.VirtualMachineScaleSetIdentity{
 		UserAssignedIdentities: identityMap,
-		Type:                   compute.ResourceIdentityTypeSystemAssignedUserAssigned,
+		Type:                   to.Ptr(armcompute.ResourceIdentityTypeSystemAssignedUserAssigned),
 	}
 	return nil
 }

--- a/task/az/resources/resource_group.go
+++ b/task/az/resources/resource_group.go
@@ -2,10 +2,11 @@ package resources
 
 import (
 	"context"
+	"errors"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	"terraform-provider-iterative/task/az/client"
 	"terraform-provider-iterative/task/common"
@@ -14,12 +15,13 @@ import (
 func ListResourceGroups(ctx context.Context, client *client.Client) ([]common.Identifier, error) {
 	ids := []common.Identifier{}
 
-	for page, err := client.Services.Groups.List(ctx, "", nil); page.NotDone(); err = page.Next() {
+	for pager := client.Services.ResourceGroups.NewListPager(nil); pager.More(); {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, group := range page.Values() {
+		for _, group := range page.ResourceGroupListResult.Value {
 			if id, err := common.ParseIdentifier(*group.Name); err == nil {
 				ids = append(ids, id)
 			}
@@ -39,35 +41,38 @@ func NewResourceGroup(client *client.Client, identifier common.Identifier) *Reso
 type ResourceGroup struct {
 	client     *client.Client
 	Identifier string
-	Resource   *resources.Group
+	Resource   *armresources.ResourceGroup
 }
 
 func (r *ResourceGroup) Create(ctx context.Context) error {
-	resourceGroup, err := r.client.Services.Groups.CreateOrUpdate(
+	response, err := r.client.Services.ResourceGroups.CreateOrUpdate(
 		ctx,
 		r.Identifier,
-		resources.Group{
-			Location: to.StringPtr(r.client.Region),
+		armresources.ResourceGroup{
+			Location: to.Ptr(r.client.Region),
 			Tags:     r.client.Tags,
-		})
+		},
+		nil,
+	)
 	if err != nil {
 		return err
 	}
 
-	r.Resource = &resourceGroup
+	r.Resource = &response.ResourceGroup
 	return nil
 }
 
 func (r *ResourceGroup) Read(ctx context.Context) error {
-	resourceGroup, err := r.client.Services.Groups.Get(ctx, r.Identifier)
+	response, err := r.client.Services.ResourceGroups.Get(ctx, r.Identifier, nil)
 	if err != nil {
-		if err.(autorest.DetailedError).StatusCode == 404 {
+		var e *azcore.ResponseError
+		if errors.As(err, &e) && e.RawResponse.StatusCode == 404 {
 			return common.NotFoundError
 		}
 		return err
 	}
 
-	r.Resource = &resourceGroup
+	r.Resource = &response.ResourceGroup
 	return nil
 }
 
@@ -76,15 +81,16 @@ func (r *ResourceGroup) Update(ctx context.Context) error {
 }
 
 func (r *ResourceGroup) Delete(ctx context.Context) error {
-	resourceGroupDeleteFuture, err := r.client.Services.Groups.Delete(ctx, r.Identifier, "")
+	poller, err := r.client.Services.ResourceGroups.BeginDelete(ctx, r.Identifier, nil)
 	if err != nil {
-		if err.(autorest.DetailedError).StatusCode == 404 {
+		var e *azcore.ResponseError
+		if errors.As(err, &e) && e.RawResponse.StatusCode == 404 {
 			return nil
 		}
 		return err
 	}
 
-	err = resourceGroupDeleteFuture.WaitForCompletionRef(ctx, r.client.Services.Groups.Client)
+	_, err = poller.PollUntilDone(ctx, nil)
 	r.Resource = nil
 	return err
 }

--- a/task/az/resources/resource_security_group.go
+++ b/task/az/resources/resource_security_group.go
@@ -2,12 +2,13 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 
 	"terraform-provider-iterative/task/az/client"
 	"terraform-provider-iterative/task/common"
@@ -15,7 +16,7 @@ import (
 
 func NewSecurityGroup(client *client.Client, identifier common.Identifier, resourceGroup *ResourceGroup, firewall common.Firewall) *SecurityGroup {
 	s := &SecurityGroup{
-		client:                 client,
+		client:     client,
 		Identifier: identifier.Long(),
 		Attributes: firewall,
 	}
@@ -30,11 +31,11 @@ type SecurityGroup struct {
 	Dependencies struct {
 		ResourceGroup *ResourceGroup
 	}
-	Resource *network.SecurityGroup
+	Resource *armnetwork.SecurityGroup
 }
 
 func (s *SecurityGroup) Create(ctx context.Context) error {
-	var rules []network.SecurityRule
+	var rules []*armnetwork.SecurityRule
 	var ingressNets, egressNets []string
 	var ingressPorts, egressPorts []string
 
@@ -69,28 +70,28 @@ func (s *SecurityGroup) Create(ctx context.Context) error {
 
 	for netIndex, netValue := range ingressNets {
 		for portIndex, portValue := range ingressPorts {
-			rules = append(rules, generateSecurityRule(netValue, portValue, uint16(netIndex*len(ingressPorts)+portIndex), network.SecurityRuleDirectionInbound))
+			rules = append(rules, generateSecurityRule(netValue, portValue, uint16(netIndex*len(ingressPorts)+portIndex), armnetwork.SecurityRuleDirectionInbound))
 		}
 	}
 	for netIndex, netValue := range egressNets {
 		for portIndex, portValue := range egressPorts {
-			rules = append(rules, generateSecurityRule(netValue, portValue, uint16(netIndex*len(egressPorts)+portIndex), network.SecurityRuleDirectionOutbound))
+			rules = append(rules, generateSecurityRule(netValue, portValue, uint16(netIndex*len(egressPorts)+portIndex), armnetwork.SecurityRuleDirectionOutbound))
 		}
 	}
 
-	securityGroupCreateFuture, err := s.client.Services.SecurityGroups.CreateOrUpdate(ctx, s.Dependencies.ResourceGroup.Identifier, s.Identifier, network.SecurityGroup{
+	poller, err := s.client.Services.SecurityGroups.BeginCreateOrUpdate(ctx, s.Dependencies.ResourceGroup.Identifier, s.Identifier, armnetwork.SecurityGroup{
 		Tags:     s.client.Tags,
-		Location: to.StringPtr(s.client.Region),
-		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-			SecurityRules: &rules,
+		Location: to.Ptr(s.client.Region),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: rules,
 		},
-	})
+	}, nil)
 
 	if err != nil {
 		return err
 	}
 
-	if err := securityGroupCreateFuture.WaitForCompletionRef(ctx, s.client.Services.SecurityGroups.Client); err != nil {
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return err
 	}
 
@@ -98,15 +99,16 @@ func (s *SecurityGroup) Create(ctx context.Context) error {
 }
 
 func (s *SecurityGroup) Read(ctx context.Context) error {
-	securityGroup, err := s.client.Services.SecurityGroups.Get(ctx, s.Dependencies.ResourceGroup.Identifier, s.Identifier, "")
+	response, err := s.client.Services.SecurityGroups.Get(ctx, s.Dependencies.ResourceGroup.Identifier, s.Identifier, nil)
 	if err != nil {
-		if err.(autorest.DetailedError).StatusCode == 404 {
+		var e *azcore.ResponseError
+		if errors.As(err, &e) && e.RawResponse.StatusCode == 404 {
 			return common.NotFoundError
 		}
 		return err
 	}
 
-	s.Resource = &securityGroup
+	s.Resource = &response.SecurityGroup
 	return nil
 }
 
@@ -115,31 +117,34 @@ func (s *SecurityGroup) Update(ctx context.Context) error {
 }
 
 func (s *SecurityGroup) Delete(ctx context.Context) error {
-	groupDeleteFuture, err := s.client.Services.SecurityGroups.Delete(ctx, s.Dependencies.ResourceGroup.Identifier, s.Identifier)
+	poller, err := s.client.Services.SecurityGroups.BeginDelete(ctx, s.Dependencies.ResourceGroup.Identifier, s.Identifier, nil)
 	if err != nil {
-		if err.(autorest.DetailedError).StatusCode == 404 {
+		var e *azcore.ResponseError
+		if errors.As(err, &e) && e.RawResponse.StatusCode == 404 {
 			return nil
 		}
 		return err
 	}
 
-	err = groupDeleteFuture.WaitForCompletionRef(ctx, s.client.Services.Groups.Client)
+	_, err = poller.PollUntilDone(ctx, nil)
 	s.Resource = nil
 	return err
 }
 
-func generateSecurityRule(net, port string, priority uint16, direction network.SecurityRuleDirection) network.SecurityRule {
-	return network.SecurityRule{
-		Name: to.StringPtr(fmt.Sprintf("%s-%d", direction, priority)),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Protocol:                 network.SecurityRuleProtocolAsterisk,
-			SourceAddressPrefix:      to.StringPtr("*"),
-			SourcePortRange:          to.StringPtr("*"),
-			DestinationAddressPrefix: to.StringPtr(net),
-			DestinationPortRange:     to.StringPtr(port),
-			Access:                   network.SecurityRuleAccessAllow,
-			Priority:                 to.Int32Ptr(int32(100 + priority)),
-			Direction:                direction,
+func generateSecurityRule(net, port string, priority uint16, direction armnetwork.SecurityRuleDirection) *armnetwork.SecurityRule {
+	securityRuleProtocolAsterisk := armnetwork.SecurityRuleProtocolAsterisk
+	securityRuleAccessAllow := armnetwork.SecurityRuleAccessAllow
+	return &armnetwork.SecurityRule{
+		Name: to.Ptr(fmt.Sprintf("%s-%d", direction, priority)),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:                 &securityRuleProtocolAsterisk,
+			SourceAddressPrefix:      to.Ptr("*"),
+			SourcePortRange:          to.Ptr("*"),
+			DestinationAddressPrefix: to.Ptr(net),
+			DestinationPortRange:     to.Ptr(port),
+			Access:                   &securityRuleAccessAllow,
+			Priority:                 to.Ptr(int32(100 + priority)),
+			Direction:                &direction,
 		},
 	}
 }

--- a/task/az/resources/resource_security_group.go
+++ b/task/az/resources/resource_security_group.go
@@ -132,17 +132,15 @@ func (s *SecurityGroup) Delete(ctx context.Context) error {
 }
 
 func generateSecurityRule(net, port string, priority uint16, direction armnetwork.SecurityRuleDirection) *armnetwork.SecurityRule {
-	securityRuleProtocolAsterisk := armnetwork.SecurityRuleProtocolAsterisk
-	securityRuleAccessAllow := armnetwork.SecurityRuleAccessAllow
 	return &armnetwork.SecurityRule{
 		Name: to.Ptr(fmt.Sprintf("%s-%d", direction, priority)),
 		Properties: &armnetwork.SecurityRulePropertiesFormat{
-			Protocol:                 &securityRuleProtocolAsterisk,
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolAsterisk),
 			SourceAddressPrefix:      to.Ptr("*"),
 			SourcePortRange:          to.Ptr("*"),
 			DestinationAddressPrefix: to.Ptr(net),
 			DestinationPortRange:     to.Ptr(port),
-			Access:                   &securityRuleAccessAllow,
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
 			Priority:                 to.Ptr(int32(100 + priority)),
 			Direction:                &direction,
 		},

--- a/task/az/resources/resource_storage_account.go
+++ b/task/az/resources/resource_storage_account.go
@@ -33,25 +33,20 @@ type StorageAccount struct {
 }
 
 func (s *StorageAccount) Create(ctx context.Context) error {
-	skuNameStandardLRS := armstorage.SKUNameStandardLRS
-	skuTierStandard := armstorage.SKUTierStandard
-	kindBlobStorage := armstorage.KindBlobStorage
-	accessTierHot := armstorage.AccessTierHot
-
 	poller, err := s.client.Services.StorageAccounts.BeginCreate(
 		ctx,
 		s.Dependencies.ResourceGroup.Identifier,
 		s.Identifier,
 		armstorage.AccountCreateParameters{
 			SKU: &armstorage.SKU{
-				Name: &skuNameStandardLRS,
-				Tier: &skuTierStandard,
+				Name: to.Ptr(armstorage.SKUNameStandardLRS),
+				Tier: to.Ptr(armstorage.SKUTierStandard),
 			},
-			Kind:     &kindBlobStorage,
+			Kind:     to.Ptr(armstorage.KindBlobStorage),
 			Location: to.Ptr(s.client.Region),
 			Tags:     s.client.Tags,
 			Properties: &armstorage.AccountPropertiesCreateParameters{
-				AccessTier: &accessTierHot,
+				AccessTier: to.Ptr(armstorage.AccessTierHot),
 			},
 		},
 		nil,

--- a/task/az/resources/resource_virtual_machine_scale_set.go
+++ b/task/az/resources/resource_virtual_machine_scale_set.go
@@ -9,10 +9,10 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	"github.com/sirupsen/logrus"
 
@@ -59,7 +59,7 @@ type VirtualMachineScaleSet struct {
 		Credentials   *Credentials
 		PermissionSet *PermissionSet
 	}
-	Resource *compute.VirtualMachineScaleSet
+	Resource *armcompute.VirtualMachineScaleSet
 }
 
 func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
@@ -123,64 +123,64 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 		size = val
 	}
 
-	settings := compute.VirtualMachineScaleSet{
+	settings := armcompute.VirtualMachineScaleSet{
 		Tags:     v.client.Tags,
-		Location: to.StringPtr(v.client.Region),
-		Sku: &compute.Sku{
-			Name:     to.StringPtr(size),
-			Tier:     to.StringPtr("Standard"),
-			Capacity: to.Int64Ptr(0),
+		Location: to.Ptr(v.client.Region),
+		SKU: &armcompute.SKU{
+			Name:     to.Ptr(size),
+			Tier:     to.Ptr("Standard"),
+			Capacity: to.Ptr(int64(0)),
 		},
 		Identity: v.Dependencies.PermissionSet.Resource,
-		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-			UpgradePolicy: &compute.UpgradePolicy{
-				Mode: compute.UpgradeModeManual,
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			UpgradePolicy: &armcompute.UpgradePolicy{
+				Mode: to.Ptr(armcompute.UpgradeModeManual),
 			},
-			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
-				StorageProfile: &compute.VirtualMachineScaleSetStorageProfile{
-					ImageReference: &compute.ImageReference{
-						Publisher: to.StringPtr(publisher),
-						Offer:     to.StringPtr(offer),
-						Sku:       to.StringPtr(sku),
-						Version:   to.StringPtr(version),
+			VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
+				StorageProfile: &armcompute.VirtualMachineScaleSetStorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr(publisher),
+						Offer:     to.Ptr(offer),
+						SKU:       to.Ptr(sku),
+						Version:   to.Ptr(version),
 					},
-					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
-						Caching:      compute.CachingTypesReadWrite,
-						CreateOption: compute.DiskCreateOptionTypesFromImage,
-						ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
-							StorageAccountType: compute.StorageAccountTypesStandardLRS,
+					OSDisk: &armcompute.VirtualMachineScaleSetOSDisk{
+						Caching:      to.Ptr(armcompute.CachingTypesReadWrite),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
+						ManagedDisk: &armcompute.VirtualMachineScaleSetManagedDiskParameters{
+							StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS),
 						},
 					},
 				},
-				OsProfile: &compute.VirtualMachineScaleSetOSProfile{
-					ComputerNamePrefix: to.StringPtr("tpi"),
-					CustomData:         to.StringPtr(base64.StdEncoding.EncodeToString([]byte(script))),
-					AdminUsername:      to.StringPtr(sshUser),
-					LinuxConfiguration: &compute.LinuxConfiguration{
-						SSH: &compute.SSHConfiguration{
-							PublicKeys: &[]compute.SSHPublicKey{
+				OSProfile: &armcompute.VirtualMachineScaleSetOSProfile{
+					ComputerNamePrefix: to.Ptr("tpi"),
+					CustomData:         to.Ptr(base64.StdEncoding.EncodeToString([]byte(script))),
+					AdminUsername:      to.Ptr(sshUser),
+					LinuxConfiguration: &armcompute.LinuxConfiguration{
+						SSH: &armcompute.SSHConfiguration{
+							PublicKeys: []*armcompute.SSHPublicKey{
 								{
-									Path:    to.StringPtr(fmt.Sprintf("/home/%s/.ssh/authorized_keys", sshUser)),
-									KeyData: to.StringPtr(publicKey),
+									Path:    to.Ptr(fmt.Sprintf("/home/%s/.ssh/authorized_keys", sshUser)),
+									KeyData: to.Ptr(publicKey),
 								},
 							},
 						},
 					},
 				},
-				NetworkProfile: &compute.VirtualMachineScaleSetNetworkProfile{
-					NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
+				NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
+					NetworkInterfaceConfigurations: []*armcompute.VirtualMachineScaleSetNetworkConfiguration{
 						{
-							Name: to.StringPtr(v.Identifier),
-							VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-								Primary:              to.BoolPtr(true),
-								NetworkSecurityGroup: &compute.SubResource{ID: v.Dependencies.SecurityGroup.Resource.ID},
-								IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+							Name: to.Ptr(v.Identifier),
+							Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+								Primary:              to.Ptr(true),
+								NetworkSecurityGroup: &armcompute.SubResource{ID: v.Dependencies.SecurityGroup.Resource.ID},
+								IPConfigurations: []*armcompute.VirtualMachineScaleSetIPConfiguration{
 									{
-										Name: to.StringPtr(v.Identifier),
-										VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-											Subnet: &compute.APIEntityReference{ID: v.Dependencies.Subnet.Resource.ID},
-											PublicIPAddressConfiguration: &compute.VirtualMachineScaleSetPublicIPAddressConfiguration{
-												Name: to.StringPtr(v.Identifier),
+										Name: to.Ptr(v.Identifier),
+										Properties: &armcompute.VirtualMachineScaleSetIPConfigurationProperties{
+											Subnet: &armcompute.APIEntityReference{ID: v.Dependencies.Subnet.Resource.ID},
+											PublicIPAddressConfiguration: &armcompute.VirtualMachineScaleSetPublicIPAddressConfiguration{
+												Name: to.Ptr(v.Identifier),
 											},
 										},
 									},
@@ -194,14 +194,14 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 	}
 
 	if size := v.Attributes.Size.Storage; size > 0 {
-		settings.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB = to.Int32Ptr(int32(size))
+		settings.Properties.VirtualMachineProfile.StorageProfile.OSDisk.DiskSizeGB = to.Ptr(int32(size))
 	}
 
 	if plan == "#plan" {
-		settings.Plan = &compute.Plan{
-			Publisher: to.StringPtr(publisher),
-			Product:   to.StringPtr(offer),
-			Name:      to.StringPtr(sku),
+		settings.Plan = &armcompute.Plan{
+			Publisher: to.Ptr(publisher),
+			Product:   to.Ptr(offer),
+			Name:      to.Ptr(sku),
 		}
 	}
 
@@ -210,24 +210,25 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 		if spot == 0 {
 			spot = -1
 		}
-		settings.VirtualMachineScaleSetProperties.VirtualMachineProfile.EvictionPolicy = compute.Delete
-		settings.VirtualMachineScaleSetProperties.VirtualMachineProfile.Priority = compute.Spot
-		settings.VirtualMachineScaleSetProperties.VirtualMachineProfile.BillingProfile = &compute.BillingProfile{
-			MaxPrice: to.Float64Ptr(float64(spot)),
+		*settings.Properties.VirtualMachineProfile.EvictionPolicy = armcompute.VirtualMachineEvictionPolicyTypesDelete
+		*settings.Properties.VirtualMachineProfile.Priority = armcompute.VirtualMachinePriorityTypesSpot
+		settings.Properties.VirtualMachineProfile.BillingProfile = &armcompute.BillingProfile{
+			MaxPrice: to.Ptr(float64(spot)),
 		}
 	}
 
-	future, err := v.client.Services.VirtualMachineScaleSets.CreateOrUpdate(
+	poller, err := v.client.Services.VirtualMachineScaleSets.BeginCreateOrUpdate(
 		ctx,
 		v.Dependencies.ResourceGroup.Identifier,
 		v.Identifier,
 		settings,
+		nil,
 	)
 	if err != nil {
 		return err
 	}
 
-	if err := future.WaitForCompletionRef(ctx, v.client.Services.VirtualMachineScaleSets.Client); err != nil {
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return err
 	}
 
@@ -235,9 +236,10 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 }
 
 func (v *VirtualMachineScaleSet) Read(ctx context.Context) error {
-	scaleSet, err := v.client.Services.VirtualMachineScaleSets.Get(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier)
+	response, err := v.client.Services.VirtualMachineScaleSets.Get(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier, nil)
 	if err != nil {
-		if err.(autorest.DetailedError).StatusCode == 404 {
+		var e *azcore.ResponseError
+		if errors.As(err, &e) && e.RawResponse.StatusCode == 404 {
 			return common.NotFoundError
 		}
 		return err
@@ -245,55 +247,53 @@ func (v *VirtualMachineScaleSet) Read(ctx context.Context) error {
 
 	v.Attributes.Events = []common.Event{}
 	v.Attributes.Status = common.Status{common.StatusCodeActive: 0}
-	scaleSetView, err := v.client.Services.VirtualMachineScaleSets.GetInstanceView(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier)
+	scaleSetView, err := v.client.Services.VirtualMachineScaleSets.GetInstanceView(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier, nil)
 	if err != nil {
 		return err
 	}
 	if scaleSetView.VirtualMachine.StatusesSummary != nil {
-		for _, status := range *scaleSetView.VirtualMachine.StatusesSummary {
-			code := to.String(status.Code)
-			logrus.Debug("ScaleSet Status Summary:", code, int(to.Int32(status.Count)))
+		for _, status := range scaleSetView.VirtualMachine.StatusesSummary {
+			code := *status.Code
+			logrus.Debug("ScaleSet Status Summary:", code, int(*status.Count))
 			if code == "ProvisioningState/succeeded" {
-				v.Attributes.Status[common.StatusCodeActive] = int(to.Int32(status.Count))
+				v.Attributes.Status[common.StatusCodeActive] = int(*status.Count)
 			}
 		}
 	}
 	if scaleSetView.Statuses != nil {
-		for _, status := range *scaleSetView.Statuses {
+		for _, status := range scaleSetView.Statuses {
 			statusTime := time.Unix(0, 0)
 			if status.Time != nil {
-				statusTime = status.Time.Time
+				statusTime = *status.Time
 			}
 			v.Attributes.Events = append(v.Attributes.Events, common.Event{
 				Time: statusTime,
-				Code: to.String(status.Code),
+				Code: *status.Code,
 				Description: []string{
-					string(status.Level),
-					to.String(status.DisplayStatus),
-					to.String(status.Message),
+					string(*status.Level),
+					*status.DisplayStatus,
+					*status.Message,
 				},
 			})
 		}
 	}
 
 	v.Attributes.Addresses = []net.IP{}
-	machineListPages, err := v.client.Services.PublicIPAddresses.ListVirtualMachineScaleSetPublicIPAddresses(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier)
-	if err != nil {
-		return err
-	}
 
-	for machineListPages.NotDone() {
-		for _, machine := range machineListPages.Values() {
-			if address := net.ParseIP(to.String(machine.PublicIPAddressPropertiesFormat.IPAddress)); address != nil {
+	for pager := v.client.Services.PublicIPAddresses.NewListPager(v.Dependencies.ResourceGroup.Identifier, nil); pager.More(); {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, machine := range page.PublicIPAddressListResult.Value {
+			if address := net.ParseIP(*machine.Properties.IPAddress); address != nil {
 				v.Attributes.Addresses = append(v.Attributes.Addresses, address)
 			}
 		}
-		if err := machineListPages.NextWithContext(ctx); err != nil {
-			return err
-		}
 	}
 
-	v.Resource = &scaleSet
+	v.Resource = &response.VirtualMachineScaleSet
 	return nil
 }
 
@@ -302,18 +302,19 @@ func (v *VirtualMachineScaleSet) Update(ctx context.Context) error {
 		return err
 	}
 
-	v.Resource.Sku.Capacity = to.Int64Ptr(int64(*v.Attributes.Parallelism))
-	future, err := v.client.Services.VirtualMachineScaleSets.CreateOrUpdate(
+	v.Resource.SKU.Capacity = to.Ptr(int64(*v.Attributes.Parallelism))
+	poller, err := v.client.Services.VirtualMachineScaleSets.BeginCreateOrUpdate(
 		ctx,
 		v.Dependencies.ResourceGroup.Identifier,
 		v.Identifier,
 		*v.Resource,
+		nil,
 	)
 	if err != nil {
 		return err
 	}
 
-	if err := future.WaitForCompletionRef(ctx, v.client.Services.VirtualMachineScaleSets.Client); err != nil {
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return err
 	}
 
@@ -321,15 +322,16 @@ func (v *VirtualMachineScaleSet) Update(ctx context.Context) error {
 }
 
 func (v *VirtualMachineScaleSet) Delete(ctx context.Context) error {
-	future, err := v.client.Services.VirtualMachineScaleSets.Delete(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier)
+	poller, err := v.client.Services.VirtualMachineScaleSets.BeginDelete(ctx, v.Dependencies.ResourceGroup.Identifier, v.Identifier, nil)
 	if err != nil {
-		if err.(autorest.DetailedError).StatusCode == 404 {
+		var e *azcore.ResponseError
+		if errors.As(err, &e) && e.RawResponse.StatusCode == 404 {
 			return nil
 		}
 		return err
 	}
 
-	if err := future.WaitForCompletionRef(ctx, v.client.Services.VirtualMachineScaleSets.Client); err != nil {
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Implements the [new command-line interface authentication mode](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/README.md#authenticating-via-the-azure-cli) required for #680 to work out of the box. Changes were performed following the [official migration guide](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/MIGRATION_GUIDE.md), more or less.


> **Warning**
> Breaks deterministic SSH key pair generation