### PR TITLE
Revert OIDC changes for `az` tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,6 +43,10 @@ jobs:
         provider: [AWS, AZ, GCP]
     concurrency: ${{ github.workflow }}-${{ matrix.provider }}
     env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       GOOGLE_APPLICATION_CREDENTIALS_DATA: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_DATA }}
       SMOKE_TEST_ENABLE_${{ matrix.provider }}: true
     steps:
@@ -57,12 +61,6 @@ jobs:
       with:
         aws-region: us-west-1
         role-to-assume: arn:aws:iam::342840881361:role/SandboxUser
-    - if: matrix.provider == 'AZ'
-      uses: azure/login@v1
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - run: go test ./task -v -timeout=30m -count=1 -tags=smoke
     - if: always()
       uses: actions/checkout@v3


### PR DESCRIPTION
Partially reverts #680 for `az` because #684 is technicallly inviable and alternatives would require too much effort to implement. Still, `k8s` will remain using OpenID Connect.