### PR TITLE
Update nvidia container support package

### DIFF
--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -37,7 +37,7 @@ if [ ! -f "$FILE" ]; then
 
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt update && sudo apt-get install -y nvidia-container-toolkit
+    sudo apt update && sudo apt install -y nvidia-container-toolkit
     sudo systemctl restart docker
   fi
 

--- a/environment/setup.sh
+++ b/environment/setup.sh
@@ -37,7 +37,7 @@ if [ ! -f "$FILE" ]; then
 
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt update && sudo apt install -y nvidia-docker2
+    sudo apt update && sudo apt-get install -y nvidia-container-toolkit
     sudo systemctl restart docker
   fi
 

--- a/iterative/testdata/script_template_cloud_aws.golden
+++ b/iterative/testdata/script_template_cloud_aws.golden
@@ -38,7 +38,7 @@ if [ ! -f "$FILE" ]; then
 
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt update && sudo apt install -y nvidia-docker2
+    sudo apt update && sudo apt install -y nvidia-container-toolkit
     sudo systemctl restart docker
   fi
 

--- a/iterative/testdata/script_template_cloud_azure.golden
+++ b/iterative/testdata/script_template_cloud_azure.golden
@@ -38,7 +38,7 @@ if [ ! -f "$FILE" ]; then
 
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt update && sudo apt install -y nvidia-docker2
+    sudo apt update && sudo apt install -y nvidia-container-toolkit
     sudo systemctl restart docker
   fi
 

--- a/iterative/testdata/script_template_cloud_gcp.golden
+++ b/iterative/testdata/script_template_cloud_gcp.golden
@@ -38,7 +38,7 @@ if [ ! -f "$FILE" ]; then
 
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt update && sudo apt install -y nvidia-docker2
+    sudo apt update && sudo apt install -y nvidia-container-toolkit
     sudo systemctl restart docker
   fi
 

--- a/iterative/testdata/script_template_cloud_invalid.golden
+++ b/iterative/testdata/script_template_cloud_invalid.golden
@@ -38,7 +38,7 @@ if [ ! -f "$FILE" ]; then
 
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt update && sudo apt install -y nvidia-docker2
+    sudo apt update && sudo apt install -y nvidia-container-toolkit
     sudo systemctl restart docker
   fi
 


### PR DESCRIPTION
Replaced the deprecated nvidia package with the new `nvidia-container-utils` as mentioned in the official [documentation](https://github.com/NVIDIA/nvidia-docker/tree/36e7a11c52f300668099ee500791e07302810007)