### PR TITLE
Use `fetch-depth: 0` for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod


### PR DESCRIPTION
[“Oderwise”](https://en.wikipedia.org/wiki/Blinkenlights) the tag bump step [fails](https://github.com/iterative/terraform-provider-iterative/actions/runs/3217043672/jobs/5259571435#step:5:45) and the release doesn't ever get published.