### PR TITLE
Fix `test -v` on smoke tests

### DIFF
--- a/task/task_smoke_test.go
+++ b/task/task_smoke_test.go
@@ -90,7 +90,7 @@ func TestTaskSmoke(t *testing.T) {
 		testName = "smoke test"
 	}
 
-	script := `#!/bin/sh -e
+	script := `#!/bin/bash -e
 		test -v TEST_GPU && nvidia-smi
 		mkdir --parents cache output
 		touch cache/file


### PR DESCRIPTION
It turns out that `sh` doesn't understand `test -v`

https://github.com/iterative/terraform-provider-iterative/actions/runs/3239053637/jobs/5307980798#step:5:645