### PR TITLE
Use `d.Id()` on Google Cloud machines

### DIFF
--- a/cmd/leo/destroyrunner/destroyrunner.go
+++ b/cmd/leo/destroyrunner/destroyrunner.go
@@ -16,7 +16,6 @@ import (
 )
 
 type Options struct {
-	Name string
 }
 
 func New(cloud *common.Cloud) *cobra.Command {
@@ -33,21 +32,12 @@ func New(cloud *common.Cloud) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&o.Name, "name", "", "needed for Google Cloud runners") // FIXME: it shouldn't
-
 	return cmd
 }
 
 func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) error {
-	r := map[string]interface{}{
-		"region": string(cloud.Region),
-		"name":   o.Name,
-	}
-	s := map[string]*schema.Schema{
-		"region": {Type: schema.TypeString},
-		"name":   {Type: schema.TypeString},
-	}
-
+	r := map[string]interface{}{"region": string(cloud.Region)}
+	s := map[string]*schema.Schema{"region": {Type: schema.TypeString}}
 	d := schema.TestResourceDataRaw(&testing.RuntimeT{}, s, r)
 	d.SetId(args[0])
 

--- a/iterative/gcp/provider.go
+++ b/iterative/gcp/provider.go
@@ -31,7 +31,7 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	networkName := "iterative"
-	instanceName := d.Get("name").(string)
+	instanceName := d.Id()
 	instanceZone := getRegion(d.Get("region").(string))
 	instanceHddSize := int64(d.Get("instance_hdd_size").(int))
 	instancePublicSshKey := fmt.Sprintf("%s:%s %s\n", "ubuntu", strings.TrimSpace(d.Get("ssh_public").(string)), "ubuntu")
@@ -281,7 +281,7 @@ func ResourceMachineDelete(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	instanceZone := getRegion(d.Get("region").(string))
-	instanceName := d.Get("name").(string)
+	instanceName := d.Id()
 
 	service.Instances.Delete(project, instanceZone, instanceName).Do()
 	service.Firewalls.Delete(project, instanceName+"-ingress").Do()


### PR DESCRIPTION
Closes #694; releasing this change may cause a hiccup in some Google Cloud users' runners.