### PR TITLE
Fix tpi workload.

### DIFF
--- a/task/common/machine/machine-script.sh.tpl
+++ b/task/common/machine/machine-script.sh.tpl
@@ -61,9 +61,8 @@ sudo tee /etc/systemd/system/tpi-task.service > /dev/null <<END
   WantedBy=default.target
 END
 
-curl --location --remote-name https://github.com/iterative/terraform-provider-iterative/releases/latest/download/terraform-provider-iterative_linux_amd64
-# TODO: replace download location with https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64
-sudo mv terraform-provider-iterative* /usr/bin/leo
+curl --location --remote-name https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64
+sudo mv leo* /usr/bin/leo
 sudo chmod u=rwx,g=rx,o=rx /usr/bin/leo
 sudo chown root:root /usr/bin/leo
 

--- a/task/common/machine/testdata/machine_script_full.golden
+++ b/task/common/machine/testdata/machine_script_full.golden
@@ -61,9 +61,8 @@ sudo tee /etc/systemd/system/tpi-task.service > /dev/null <<END
   WantedBy=default.target
 END
 
-curl --location --remote-name https://github.com/iterative/terraform-provider-iterative/releases/latest/download/terraform-provider-iterative_linux_amd64
-# TODO: replace download location with https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64
-sudo mv terraform-provider-iterative* /usr/bin/leo
+curl --location --remote-name https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64
+sudo mv leo* /usr/bin/leo
 sudo chmod u=rwx,g=rx,o=rx /usr/bin/leo
 sudo chown root:root /usr/bin/leo
 

--- a/task/common/machine/testdata/machine_script_minimal.golden
+++ b/task/common/machine/testdata/machine_script_minimal.golden
@@ -61,9 +61,8 @@ sudo tee /etc/systemd/system/tpi-task.service > /dev/null <<END
   WantedBy=default.target
 END
 
-curl --location --remote-name https://github.com/iterative/terraform-provider-iterative/releases/latest/download/terraform-provider-iterative_linux_amd64
-# TODO: replace download location with https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64
-sudo mv terraform-provider-iterative* /usr/bin/leo
+curl --location --remote-name https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64
+sudo mv leo* /usr/bin/leo
 sudo chmod u=rwx,g=rx,o=rx /usr/bin/leo
 sudo chown root:root /usr/bin/leo
 


### PR DESCRIPTION
After the landing of the tpi command split PR, the machine script was still downloading the terraform-provider-iterative release artifact.
This caused the task to not be run properly.