### PR TITLE
Makefile - Make it a bit more usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ vendor
 
 # ignore binaries in the root dir
 terraform-provider-iterative
-leo-*
+leo
 
 # JetBrains IDEs
 .idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,9 @@ terraform
 # Ignore the Go vendor directory, superseded by proxy.golang.org and go.{mod,sum}
 vendor
 
+# ignore binaries in the root dir
 terraform-provider-iterative
+leo-*
+
+# JetBrains IDEs
+.idea/*

--- a/Makefile
+++ b/Makefile
@@ -9,22 +9,24 @@ TPI_PATH ?= $(shell pwd)
 LEO_PATH ?= $(shell pwd)/cmd/leo
 GO_LINK_FLAGS ?= -s -w -X terraform-provider-iterative/iterative/utils.Version=${VERSION}
 
-LEO_BUILD_COMMAND ?= \
-	CGO_ENABLED=0 \
-	go build -ldflags="$(GO_LINK_FLAGS)" \
-	-o $(shell pwd)/leo-$(GOOS)-$(GOARCH) \
-	$(LEO_PATH)
-
 default: build
 
-# TODO: Should this be renamed to something like build-check ?
 .PHONY: build
-build:
-	go build ./...
+build: tpi leo
 
-.PHONY: leo-bin
-leo-bin:
-	$(LEO_BUILD_COMMAND)
+.PHONY: tpi
+tpi:
+	CGO_ENABLED=0 \
+    	go build -ldflags="$(GO_LINK_FLAGS)" \
+    	-o $(shell pwd)/terraform-provider-iterative \
+    	$(TPI_PATH)
+
+.PHONY: leo
+leo:
+	CGO_ENABLED=0 \
+    	go build -ldflags="$(GO_LINK_FLAGS)" \
+    	-o $(shell pwd)/leo \
+    	$(LEO_PATH)
 
 .PHONY: install_tpi
 install_tpi:
@@ -45,7 +47,3 @@ sweep:
 .PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v ${TESTARGS} -timeout 120m
-
-.PHONY: targets
-targets:
-	@awk -F: '/^[^ \t="]+:/ && !/PHONY/ {print $$1}' Makefile | sort -u

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,3 @@ smoke:
 .PHONY: sweep
 sweep:
 	SMOKE_TEST_SWEEP=true go test ./task -v ${TESTARGS} -timeout=30m -count=1
-
-.PHONY: testacc
-testacc:
-	TF_ACC=1 go test ./... -v ${TESTARGS} -timeout 120m

--- a/Makefile
+++ b/Makefile
@@ -2,26 +2,50 @@ HOSTNAME=github.com
 NAMESPACE=iterative
 NAME=iterative
 VERSION=0.0.${shell date +%s}+development
-OS_ARCH=${shell go env GOOS}_${shell go env GOARCH}
-BINARY=terraform-provider-${NAME}
-INSTALL_PATH=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+GOOS=${shell go env GOOS}
+GOARCH=${shell go env GOARCH}
+TF_PLUGIN_INSTALL_PATH=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${GOOS}_${GOARCH}
+TPI_PATH ?= $(shell pwd)
+LEO_PATH ?= $(shell pwd)/cmd/leo
+GO_LINK_FLAGS ?= -s -w -X terraform-provider-iterative/iterative/utils.Version=${VERSION}
+
+LEO_BUILD_COMMAND ?= \
+	CGO_ENABLED=0 \
+	go build -ldflags="$(GO_LINK_FLAGS)" \
+	-o $(shell pwd)/leo-$(GOOS)-$(GOARCH) \
+	$(LEO_PATH)
 
 default: build
 
+# TODO: Should this be renamed to something like build-check ?
+.PHONY: build
 build:
 	go build ./...
 
-install_tpi:
-	GOBIN=${INSTALL_PATH} go install ./...
+.PHONY: leo-bin
+leo-bin:
+	$(LEO_BUILD_COMMAND)
 
+.PHONY: install_tpi
+install_tpi:
+	GOBIN=${TF_PLUGIN_INSTALL_PATH} go install -ldflags="$(GO_LINK_FLAGS)" $(TPI_PATH)
+
+.PHONY: test
 test:
 	go test ./... ${TESTARGS} -timeout=30s -parallel=4
 
+.PHONY: smoke
 smoke:
 	go test ./task -v ${TESTARGS} -timeout=30m -count=1 -tags=smoke
 
+.PHONY: sweep
 sweep:
 	SMOKE_TEST_SWEEP=true go test ./task -v ${TESTARGS} -timeout=30m -count=1
 
+.PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v ${TESTARGS} -timeout 120m
+
+.PHONY: targets
+targets:
+	@awk -F: '/^[^ \t="]+:/ && !/PHONY/ {print $$1}' Makefile | sort -u

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ default: build
 .PHONY: build
 build: tpi leo
 
+.PHONY: install
+install: install-tpi
+
 .PHONY: tpi
 tpi:
 	CGO_ENABLED=0 \
@@ -28,8 +31,8 @@ leo:
     	-o $(shell pwd)/leo \
     	$(LEO_PATH)
 
-.PHONY: install_tpi
-install_tpi:
+.PHONY: install-tpi
+install-tpi:
 	GOBIN=${TF_PLUGIN_INSTALL_PATH} go install -ldflags="$(GO_LINK_FLAGS)" $(TPI_PATH)
 
 .PHONY: test


### PR DESCRIPTION
- Adding target to build `leo` and `terraform-provider-iterative` binaries in repo root
- `build` target now uses the above instead of the current "check-build" (checks validity, but produces no binaries, which might be useful)
- `install_tpi` target - built and installed `leo` bin into tf plugins (probably unwanted behavior) - fixed
- Added phony directives for phony targets (which also allows for the convenience of `make targets` which acts as `--help`)
- Some light refactoring
- Addition to gitignore for JB ideas