### PR TITLE
Simple waiting feedback for leo

### DIFF
--- a/cmd/leo/read/read.go
+++ b/cmd/leo/read/read.go
@@ -70,6 +70,7 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 
 	var last int
 	firstRun := true
+	waiting := false
 	for {
 		if err := tsk.Read(ctx); err != nil {
 			return err
@@ -79,17 +80,15 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		if err != nil {
 			return err
 		}
-		if len(logs) == 0 {
-			if firstRun {
-				fmt.Print("Waiting for instance")
-			}
-			fmt.Print(".")
-		} else {
-			if !firstRun {
-				fmt.Print("\n")
-			}
+
+		if firstRun && len(logs) == 0 {
+			fmt.Print("Waiting for instance")
+			waiting = true
 		}
 		firstRun = false
+		if waiting {
+			fmt.Print(".")
+		}
 
 		status, err := o.getStatus(ctx, tsk)
 		if err != nil {
@@ -97,6 +96,10 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		}
 
 		if delta := strings.Join(logs[last:], "\n"); delta != "" {
+			if waiting {
+				fmt.Print("\n")
+				waiting = false
+			}
 			fmt.Println(delta)
 			last = len(logs)
 		}

--- a/cmd/leo/read/read.go
+++ b/cmd/leo/read/read.go
@@ -82,12 +82,12 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		}
 
 		if firstRun && len(logs) == 0 {
-			fmt.Print("Waiting for instance")
+			fmt.Fprint(os.Stderr, "Waiting for instance")
 			waiting = true
 		}
 		firstRun = false
 		if waiting {
-			fmt.Print(".")
+			fmt.Fprint(os.Stderr, ".")
 		}
 
 		status, err := o.getStatus(ctx, tsk)
@@ -97,7 +97,7 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 
 		if delta := strings.Join(logs[last:], "\n"); delta != "" {
 			if waiting {
-				fmt.Print("\n")
+				fmt.Fprint(os.Stderr, "\n")
 				waiting = false
 			}
 			fmt.Println(delta)

--- a/cmd/leo/read/read.go
+++ b/cmd/leo/read/read.go
@@ -68,7 +68,8 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		return err
 	}
 
-        var last int
+	var last int
+	firstRun := true
 	for {
 		if err := tsk.Read(ctx); err != nil {
 			return err
@@ -78,6 +79,17 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		if err != nil {
 			return err
 		}
+		if len(logs) == 0 {
+			if firstRun {
+				fmt.Print("Waiting for instance")
+			}
+			fmt.Print(".")
+		} else {
+			if !firstRun {
+				fmt.Print("\n")
+			}
+		}
+		firstRun = false
 
 		status, err := o.getStatus(ctx, tsk)
 		if err != nil {


### PR DESCRIPTION
adds some simple feedback for when users run `leo read --follow` right after a `leo create` and there aren't any logs yet.