### PR TITLE
Fix leo read error for delete

### DIFF
--- a/cmd/leo/create/create.go
+++ b/cmd/leo/create/create.go
@@ -133,6 +133,5 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		}
 		return err
 	}
-
 	return nil
 }

--- a/cmd/leo/delete/delete.go
+++ b/cmd/leo/delete/delete.go
@@ -2,7 +2,6 @@ package delete
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -11,8 +10,9 @@ import (
 )
 
 type Options struct {
-	Workdir string
-	Output  string
+	Workdir     string
+	Output      string
+	ExcludeList []string
 }
 
 func New(cloud *common.Cloud) *cobra.Command {
@@ -39,6 +39,7 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 		Environment: common.Environment{
 			Directory:    o.Workdir,
 			DirectoryOut: o.Output,
+			ExcludeList:  o.ExcludeList,
 		},
 	}
 
@@ -54,7 +55,5 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 	if err != nil {
 		return err
 	}
-	tsk.Read(ctx)
-	fmt.Println("output dir: ", o.Output)
 	return tsk.Delete(ctx)
 }

--- a/cmd/leo/delete/delete.go
+++ b/cmd/leo/delete/delete.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -53,6 +54,7 @@ func (o *Options) Run(cmd *cobra.Command, args []string, cloud *common.Cloud) er
 	if err != nil {
 		return err
 	}
-
+	tsk.Read(ctx)
+	fmt.Println("output dir: ", o.Output)
 	return tsk.Delete(ctx)
 }

--- a/task/aws/resources/data_source_image.go
+++ b/task/aws/resources/data_source_image.go
@@ -31,6 +31,10 @@ type Image struct {
 }
 
 func (i *Image) Read(ctx context.Context) error {
+	// default image to ubuntu in not present
+	if i.Identifier == "" {
+		i.Identifier = "ubuntu"
+	}
 	image := i.Identifier
 	images := map[string]string{
 		"ubuntu": "ubuntu@099720109477:x86_64:*ubuntu/images/hvm-ssd/ubuntu-focal-20.04*",

--- a/task/az/resources/resource_virtual_machine_scale_set.go
+++ b/task/az/resources/resource_virtual_machine_scale_set.go
@@ -82,7 +82,10 @@ func (v *VirtualMachineScaleSet) Create(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to render machine script: %w", err)
 	}
-
+	// default image to ubuntu in not present
+	if v.Attributes.Environment.Image == "" {
+		v.Attributes.Environment.Image = "ubuntu"
+	}
 	image := v.Attributes.Environment.Image
 	images := map[string]string{
 		"ubuntu": "ubuntu@Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest",

--- a/task/common/steps.go
+++ b/task/common/steps.go
@@ -18,6 +18,7 @@ func RunSteps(ctx context.Context, steps []Step) error {
 	for i, step := range steps {
 		logrus.Infof("[%d/%d] %s", i+1, total, step.Description)
 		if err := step.Action(ctx); err != nil {
+			logrus.Debug("step: ", step.Description, " error: ", err)
 			return err
 		}
 	}

--- a/task/gcp/resources/data_source_image.go
+++ b/task/gcp/resources/data_source_image.go
@@ -29,6 +29,10 @@ type Image struct {
 }
 
 func (i *Image) Read(ctx context.Context) error {
+	// default image to ubuntu in not present
+	if i.Identifier == "" {
+		i.Identifier = "ubuntu"
+	}
 	image := i.Identifier
 	images := map[string]string{
 		"ubuntu": "ubuntu@ubuntu-os-cloud/ubuntu-2004-lts",


### PR DESCRIPTION
the delete wasn't syncing back data because of the read: https://github.com/iterative/terraform-provider-iterative/blob/f84401cefa3896bd26152223eb78d055fa54673f/task/aws/task.go#L248
it would try to check the Image, fail because it was not set, and then bailout from the read and continue to delete resources.

I don't think this should be the permanent solution. I think we should either use smaller parts on the existing interfaces to leo doesn't make unneeded API calls (instead of blank read for the whole task), or have a leo shutdown/close that is better suited for this (natural ending of a task syncing changes) and save delete for cleaning up broken tasks

Closes: https://github.com/iterative/terraform-provider-iterative/issues/712