### PR TITLE
Dummy test and lint jobs for ignored paths.

### DIFF
--- a/.github/workflows/test-dummy.yml
+++ b/.github/workflows/test-dummy.yml
@@ -1,0 +1,19 @@
+# test.yml ignores docs/* and **.md changes, but since the
+# `lint` and `test` statuses are required, those PRs will block.
+name: Dummy tests for unblocking PRs
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**.md'
+jobs:
+  lint:
+    if: ${{ false }} # Skipped jobs still result in 'success'.
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+  test:
+    if: ${{ false }} # Skipped jobs still result in 'success'.
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-dummy.yml
+++ b/.github/workflows/test-dummy.yml
@@ -8,12 +8,12 @@ on:
       - '**.md'
 jobs:
   lint:
-    if: ${{ false }} # Skipped jobs still result in 'success'.
+    if: false # Skipped jobs still result in 'success'.
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: false # unreachable
   test:
-    if: ${{ false }} # Skipped jobs still result in 'success'.
+    if: false # Skipped jobs still result in 'success'.
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: false # unreachable


### PR DESCRIPTION
The `test` and `lint` jobs in test.yml ignore changes to `docs/*` and
`**.md`. Since those checks are required, this results in blocked PRs.

This adds dummy tests to satisfy the required check statuses.

See #731.