### PR TITLE
Switch build-ami action to OIDC

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -5,12 +5,14 @@ on:
     paths: [environment/**]
 jobs:
   build-ami:
+    environment: aws
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::260760892802:role/cml-terraform-provider
       - run: |
           packer init environment
           packer build environment
-        env:
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -2,7 +2,9 @@ name: build-ami
 on:
   push:
     branches: [main]
-    paths: [environment/**]
+    paths:
+      - environment/**
+      - .github/workflows/build-ami.yml
 jobs:
   build-ami:
     environment: aws

--- a/environment/ami.pkr.hcl
+++ b/environment/ami.pkr.hcl
@@ -19,10 +19,8 @@ variables {
 }
 
 variables {
-  aws_role_session_name = "cml-packer-session"
-  aws_role_arn          = "arn:aws:iam::260760892802:role/cml-packer"
   aws_subnet_id         = "subnet-09fca08419c2f0575"
-  aws_security_group_id = "sg-0b7df7d9f902ca7ec"
+  aws_security_group_id = "sg-03ff7b083bdc991e5"
 }
 
 locals {
@@ -68,10 +66,6 @@ data "amazon-ami" "ubuntu" {
     virtualization-type = "hvm"
   }
 
-  assume_role {
-    role_arn     = var.aws_role_arn
-    session_name = var.aws_role_session_name
-  }
 }
 
 source "amazon-ebs" "source" {
@@ -96,10 +90,6 @@ source "amazon-ebs" "source" {
   run_tags        = local.aws_tags
   run_volume_tags = local.aws_tags
 
-  assume_role {
-    role_arn     = var.aws_role_arn
-    session_name = var.aws_role_session_name
-  }
 }
 
 build {


### PR DESCRIPTION
With iterative/itops#890 we switched terraform project name from cml to `packer-infra` to be used also for Studio-Selfhosted packer builds. Additionaly I made a role to cooperate with OIDC.