### PR TITLE
Support paths with spaces when using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,19 +21,19 @@ install: install-tpi
 tpi:
 	CGO_ENABLED=0 \
     	go build -ldflags="$(GO_LINK_FLAGS)" \
-    	-o $(shell pwd)/terraform-provider-iterative \
-    	$(TPI_PATH)
+    	-o "$(shell pwd)/terraform-provider-iterative" \
+    	"$(TPI_PATH)"
 
 .PHONY: leo
 leo:
 	CGO_ENABLED=0 \
     	go build -ldflags="$(GO_LINK_FLAGS)" \
-    	-o $(shell pwd)/leo \
-    	$(LEO_PATH)
+    	-o "$(shell pwd)/leo" \
+    	"$(LEO_PATH)"
 
 .PHONY: install-tpi
 install-tpi:
-	GOBIN=${TF_PLUGIN_INSTALL_PATH} go install -ldflags="$(GO_LINK_FLAGS)" $(TPI_PATH)
+	GOBIN=${TF_PLUGIN_INSTALL_PATH} go install -ldflags="$(GO_LINK_FLAGS)" "$(TPI_PATH)"
 
 .PHONY: test
 test:


### PR DESCRIPTION
I had issues when using `make` with paths containing spaces. This PR fixes this.

Examples in the Dev Container configuration:

```sh
$ make leo
CGO_ENABLED=0 \
        go build -ldflags="-s -w -X terraform-provider-iterative/iterative/utils.Version=0.0.1680607982+development" \
        -o /workspaces/509.20.06 terraform-provider-iterative/leo \
        /workspaces/509.20.06 terraform-provider-iterative/cmd/leo
package terraform-provider-iterative/leo is not in GOROOT (/usr/local/go/src/terraform-provider-iterative/leo)
stat /workspaces/509.20.06: directory not found
make: *** [Makefile:29: leo] Error 1
```

```sh
$ make tpi
CGO_ENABLED=0 \
        go build -ldflags="-s -w -X terraform-provider-iterative/iterative/utils.Version=0.0.1680608415+development" \
        -o /workspaces/509.20.06 terraform-provider-iterative/terraform-provider-iterative \
        ""/workspaces/509.20.06 terraform-provider-iterative""
package terraform-provider-iterative/terraform-provider-iterative is not in GOROOT (/usr/local/go/src/terraform-provider-iterative/terraform-provider-iterative)
no Go files in /workspaces/509.20.06
make: *** [Makefile:23: tpi] Error 1
```