### PR TITLE
Set new SecurityGroup ID

### DIFF
--- a/environment/ami.pkr.hcl
+++ b/environment/ami.pkr.hcl
@@ -20,7 +20,7 @@ variables {
 
 variables {
   aws_subnet_id         = "subnet-09fca08419c2f0575"
-  aws_security_group_id = "sg-03ff7b083bdc991e5"
+  aws_security_group_id = "sg-0da3ac1cdc286dd4e"
 }
 
 locals {


### PR DESCRIPTION
During cleaning the SG's in region I accidentally deleted the group used for build ;-(