### PR TITLE
Add misssing error check

### DIFF
--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -124,8 +124,11 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 	if len(securityGroup) == 0 {
 		securityGroup = "iterative"
 
-		vpcsDesc, _ := svc.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{})
-
+		vpcsDesc, err := svc.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{})
+		if err != nil {
+			return err
+		}
+		
 		if len(vpcsDesc.Vpcs) == 0 {
 			return errors.New("no VPCs found")
 		}


### PR DESCRIPTION
```
Stack trace from the terraform-provider-iterative plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x14c79f3]

goroutine 49 [running]:
terraform-provider-iterative/iterative/aws.ResourceMachineCreate({0x4095a90, 0xc0006c5560}, 0xc00090b900, {0x31cda80?, 0xc00033c2d0?})
	terraform-provider-iterative/iterative/aws/provider.go:129 +0x17d3
terraform-provider-iterative/iterative.resourceMachineCreate({0x4095a90, 0xc0006c5560}, 0xe?, {0x0, 0x0})
	terraform-provider-iterative/iterative/resource_machine.go:193 +0x765
terraform-provider-iterative/iterative.resourceRunnerCreate({0x4095a90?, 0xc0006c5560}, 0xc00090b900, {0x0?, 0x0})
	terraform-provider-iterative/iterative/resource_runner.go:240 +0x578
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc000182460, {0x4095a20, 0xc0006cd7c0}, 0x2?, {0x0, 0x0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/resource.go:330 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000182460, {0x4095a20, 0xc0006cd7c0}, 0xc0006b0c30, 0xc00090b780, {0x0, 0x0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/resource.go:456 +0x705
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc00031ff80, {0x4095a20, 0xc0006cd7c0}, 0xc00089f680)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/grpc_provider.go:977 +0xde5
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00064cda0, {0x4095ac8?, 0xc0007762a0?}, 0x0?)
	github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/tf5server/server.go:332 +0x6c
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x37d8d20?, 0xc00064cda0}, {0x4095ac8, 0xc0007762a0}, 0xc000908d20, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000452960, {0x409f1a0, 0xc00057d6c0}, 0xc00044d320, 0xc000689c20, 0x58e7ea0, 0x0)
	google.golang.org/grpc@v1.49.0/server.go:1301 +0xb2b
google.golang.org/grpc.(*Server).handleStream(0xc000452960, {0x409f1a0, 0xc00057d6c0}, 0xc00044d320, 0x0)
	google.golang.org/grpc@v1.49.0/server.go:1642 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.49.0/server.go:938 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.49.0/server.go:936 +0x28a

Error: The terraform-provider-iterative plugin crashed!
```