### PR TITLE
Use gp3 AWS volumes instead of gp2 for better default IOPS capacity

### DIFF
--- a/iterative/aws/provider.go
+++ b/iterative/aws/provider.go
@@ -128,7 +128,7 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 		if err != nil {
 			return err
 		}
-		
+
 		if len(vpcsDesc.Vpcs) == 0 {
 			return errors.New("no VPCs found")
 		}
@@ -288,7 +288,7 @@ func ResourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 				DeleteOnTermination: aws.Bool(true),
 				Encrypted:           aws.Bool(false),
 				VolumeSize:          aws.Int32(int32(hddSize)),
-				VolumeType:          types.VolumeType("gp2"),
+				VolumeType:          types.VolumeType("gp3"),
 			},
 		},
 	}

--- a/task/aws/resources/resource_launch_template.go
+++ b/task/aws/resources/resource_launch_template.go
@@ -91,7 +91,7 @@ func (l *LaunchTemplate) Create(ctx context.Context) error {
 					Ebs: &types.LaunchTemplateEbsBlockDeviceRequest{
 						DeleteOnTermination: aws.Bool(true),
 						Encrypted:           aws.Bool(false),
-						VolumeType:          types.VolumeType("gp2"),
+						VolumeType:          types.VolumeType("gp3"),
 					},
 				},
 			},


### PR DESCRIPTION
Simple change of hardcoded "gp2" volume type values to "gp3".  As per the issue below, "gp3" volume types on AWS offer a much higher default IOPS capacity for smaller HDD sizes than "gp2".

Fixes: https://github.com/iterative/terraform-provider-iterative/issues/761